### PR TITLE
Skip Calico-kube-controllers deployment for clusters without a backend

### DIFF
--- a/charts/internal/calico/templates/kube-controller/clusterrole-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/clusterrole-calico-kube-controllers.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config.kubeControllers.enabled }}
 ---
 kind: ClusterRole
 apiVersion: {{ include "rbacversion" . }}
@@ -43,3 +44,4 @@ rules:
       - get
       - create
       - update
+{{- end }}

--- a/charts/internal/calico/templates/kube-controller/clusterrole-garden-psp-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/clusterrole-garden-psp-calico-kube-controllers.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config.kubeControllers.enabled }}
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
@@ -13,3 +14,4 @@ rules:
       - podsecuritypolicies
     verbs:
       - use
+{{- end }}

--- a/charts/internal/calico/templates/kube-controller/clusterrolebinding-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/clusterrolebinding-calico-kube-controllers.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config.kubeControllers.enabled }}
 ---
 kind: ClusterRoleBinding
 apiVersion: {{ include "rbacversion" . }}
@@ -11,3 +12,4 @@ subjects:
 - kind: ServiceAccount
   name: calico-kube-controllers
   namespace: kube-system
+{{- end }}

--- a/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config.kubeControllers.enabled }}
 ---
 # Source: calico/templates/calico-kube-controllers.yaml
 # See https://github.com/projectcalico/kube-controllers
@@ -72,3 +73,4 @@ spec:
             # Health checks are written on a file which is
             # writable only to root
             privileged: true
+{{- end }}

--- a/charts/internal/calico/templates/kube-controller/psp-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/psp-calico-kube-controllers.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config.kubeControllers.enabled }}
 ---
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
@@ -20,3 +21,4 @@ spec:
     rule: RunAsAny
   fsGroup:
     rule: RunAsAny
+{{- end }}

--- a/charts/internal/calico/templates/kube-controller/rolebinding-garden-psp-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/rolebinding-garden-psp-calico-kube-controllers.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config.kubeControllers.enabled }}
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding
@@ -12,3 +13,4 @@ subjects:
   - kind: ServiceAccount
     name: calico-kube-controllers
     namespace: kube-system
+{{- end }}

--- a/charts/internal/calico/templates/kube-controller/serviceaccount-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/serviceaccount-calico-kube-controllers.yaml
@@ -1,6 +1,8 @@
+{{- if .Values.config.kubeControllers.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: calico-kube-controllers
   namespace: kube-system
+{{- end }}

--- a/charts/internal/calico/values.yaml
+++ b/charts/internal/calico/values.yaml
@@ -6,6 +6,8 @@ config:
   ipam:
     type: "host-local"
     # subnet: "usePodCidr"
+  kubeControllers:
+    enabled: true
   typha:
     enabled: true
   ipv4:

--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -34,6 +34,7 @@ import (
 
 var (
 	trueVar    = true
+	falseVar   = false
 	mtuVar     = "1430"
 	defaultMtu = "1440"
 )
@@ -156,6 +157,9 @@ var _ = Describe("Chart package test", func() {
 					"typha": map[string]interface{}{
 						"enabled": trueVar,
 					},
+					"kubeControllers": map[string]interface{}{
+						"enabled": trueVar,
+					},
 					"veth_mtu": defaultMtu,
 					"felix": map[string]interface{}{
 						"ipinip": map[string]interface{}{
@@ -197,6 +201,9 @@ var _ = Describe("Chart package test", func() {
 					},
 					"typha": map[string]interface{}{
 						"enabled": trueVar,
+					},
+					"kubeControllers": map[string]interface{}{
+						"enabled": falseVar,
 					},
 					"veth_mtu": defaultMtu,
 					"felix": map[string]interface{}{
@@ -240,6 +247,9 @@ var _ = Describe("Chart package test", func() {
 					"typha": map[string]interface{}{
 						"enabled": trueVar,
 					},
+					"kubeControllers": map[string]interface{}{
+						"enabled": trueVar,
+					},
 					"veth_mtu": defaultMtu,
 					"felix": map[string]interface{}{
 						"ipinip": map[string]interface{}{
@@ -277,6 +287,9 @@ var _ = Describe("Chart package test", func() {
 						"subnet": string(*networkConfigAll.IPAM.CIDR),
 					},
 					"typha": map[string]interface{}{
+						"enabled": trueVar,
+					},
+					"kubeControllers": map[string]interface{}{
 						"enabled": trueVar,
 					},
 					"veth_mtu": mtuVar,
@@ -319,6 +332,9 @@ var _ = Describe("Chart package test", func() {
 						"subnet": string(*networkConfigDeprecated.IPAM.CIDR),
 					},
 					"typha": map[string]interface{}{
+						"enabled": trueVar,
+					},
+					"kubeControllers": map[string]interface{}{
 						"enabled": trueVar,
 					},
 					"veth_mtu": defaultMtu,

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -32,12 +32,13 @@ const (
 )
 
 type calicoConfig struct {
-	Backend calicov1alpha1.Backend `json:"backend"`
-	Felix   felix                  `json:"felix"`
-	IPv4    ipv4                   `json:"ipv4"`
-	IPAM    ipam                   `json:"ipam"`
-	Typha   typha                  `json:"typha"`
-	VethMTU string                 `json:"veth_mtu"`
+	Backend         calicov1alpha1.Backend `json:"backend"`
+	Felix           felix                  `json:"felix"`
+	IPv4            ipv4                   `json:"ipv4"`
+	IPAM            ipam                   `json:"ipam"`
+	Typha           typha                  `json:"typha"`
+	KubeControllers kubeControllers        `json:"kubeControllers"`
+	VethMTU         string                 `json:"veth_mtu"`
 }
 
 type felix struct {
@@ -57,6 +58,10 @@ type ipv4 struct {
 type ipam struct {
 	IPAMType string `json:"type"`
 	Subnet   string `json:"subnet"`
+}
+
+type kubeControllers struct {
+	Enabled bool `json:"enabled"`
 }
 
 type typha struct {
@@ -80,6 +85,9 @@ var defaultCalicoConfig = calicoConfig{
 		Subnet:   usePodCIDR,
 	},
 	Typha: typha{
+		Enabled: true,
+	},
+	KubeControllers: kubeControllers{
 		Enabled: true,
 	},
 	VethMTU: defaultMTU,
@@ -145,6 +153,7 @@ func generateChartValues(config *calicov1alpha1.NetworkConfig) (*calicoConfig, e
 		}
 	}
 	if c.Backend == calicov1alpha1.None {
+		c.KubeControllers.Enabled = false
 		c.Felix.IPInIP.Enabled = false
 		c.IPv4.Mode = calicov1alpha1.Never
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes `calico-kube-controllers` components for clusters running without a backend (e.g., Azure). This will further improve our availability monitoring as we won't get alerts related to unused components.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Clusters without a backedend (i.e., backend is set to `None`) will run without the unneeded `calico-kube-controllers` deployment
```
