### PR TITLE
Adapt to the new API group

### DIFF
--- a/charts/internal/calico/templates/custom-resource-definition/crd-bgpconfigurations.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-bgpconfigurations.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
   labels:
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
 spec:
   scope: Cluster
   group: crd.projectcalico.org

--- a/charts/internal/calico/templates/custom-resource-definition/crd-bgppeers.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-bgppeers.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   name: bgppeers.crd.projectcalico.org
   labels:
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
 spec:
   scope: Cluster
   group: crd.projectcalico.org

--- a/charts/internal/calico/templates/custom-resource-definition/crd-blockaffinities.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-blockaffinities.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   name: blockaffinities.crd.projectcalico.org
   labels:
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
 spec:
   scope: Cluster
   group: crd.projectcalico.org

--- a/charts/internal/calico/templates/custom-resource-definition/crd-clusterinformations.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-clusterinformations.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
   labels:
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
 spec:
   scope: Cluster
   group: crd.projectcalico.org

--- a/charts/internal/calico/templates/custom-resource-definition/crd-felixconfigurations.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-felixconfigurations.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
   labels:
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
 spec:
   scope: Cluster
   group: crd.projectcalico.org

--- a/charts/internal/calico/templates/custom-resource-definition/crd-globalnetworkpolicies.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-globalnetworkpolicies.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
   labels:
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
 spec:
   scope: Cluster
   group: crd.projectcalico.org

--- a/charts/internal/calico/templates/custom-resource-definition/crd-globalnetworksets.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-globalnetworksets.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
   labels:
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
 spec:
   scope: Cluster
   group: crd.projectcalico.org

--- a/charts/internal/calico/templates/custom-resource-definition/crd-hostendpoints.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-hostendpoints.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
   labels:
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
 spec:
   scope: Cluster
   group: crd.projectcalico.org

--- a/charts/internal/calico/templates/custom-resource-definition/crd-ipamblocks.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-ipamblocks.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   name: ipamblocks.crd.projectcalico.org
   labels:
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
 spec:
   scope: Cluster
   group: crd.projectcalico.org

--- a/charts/internal/calico/templates/custom-resource-definition/crd-ipamconfigs.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-ipamconfigs.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   name: ipamconfigs.crd.projectcalico.org
   labels:
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
 spec:
   scope: Cluster
   group: crd.projectcalico.org

--- a/charts/internal/calico/templates/custom-resource-definition/crd-ipamhandles.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-ipamhandles.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   name: ipamhandles.crd.projectcalico.org
   labels:
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
 spec:
   scope: Cluster
   group: crd.projectcalico.org

--- a/charts/internal/calico/templates/custom-resource-definition/crd-ippools.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-ippools.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
   labels:
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
 spec:
   scope: Cluster
   group: crd.projectcalico.org

--- a/charts/internal/calico/templates/custom-resource-definition/crd-networkpolicies.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-networkpolicies.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
   labels:
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
 spec:
   scope: Namespaced
   group: crd.projectcalico.org

--- a/charts/internal/calico/templates/custom-resource-definition/crd-networksets.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-networksets.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   name: networksets.crd.projectcalico.org
   labels:
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
 spec:
   scope: Namespaced
   group: crd.projectcalico.org

--- a/charts/internal/calico/templates/kube-controller/clusterrole-garden-psp-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/clusterrole-garden-psp-calico-kube-controllers.yaml
@@ -3,7 +3,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: garden.sapcloud.io:psp:kube-system:calico-kube-controllers
+  name: gardener.cloud:psp:kube-system:calico-kube-controllers
 rules:
   - apiGroups:
       - policy

--- a/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     origin: gardener
     k8s-app: calico-kube-controllers
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
 spec:
@@ -29,7 +29,7 @@ spec:
       labels:
         origin: gardener
         k8s-app: calico-kube-controllers
-        garden.sapcloud.io/role: system-component
+        gardener.cloud/role: system-component
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/charts/internal/calico/templates/kube-controller/rolebinding-garden-psp-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/rolebinding-garden-psp-calico-kube-controllers.yaml
@@ -3,12 +3,12 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding
 metadata:
-  name: garden.sapcloud.io:psp:calico-kube-controllers
+  name: gardener.cloud:psp:calico-kube-controllers
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: garden.sapcloud.io:psp:kube-system:calico-kube-controllers
+  name: gardener.cloud:psp:kube-system:calico-kube-controllers
 subjects:
   - kind: ServiceAccount
     name: calico-kube-controllers

--- a/charts/internal/calico/templates/node/clusterrole-garden-psp-calico.yaml
+++ b/charts/internal/calico/templates/node/clusterrole-garden-psp-calico.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: garden.sapcloud.io:psp:kube-system:calico
+  name: gardener.cloud:psp:kube-system:calico
 rules:
 - apiGroups:
   - policy

--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     k8s-app: calico-node
     origin: gardener
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
 spec:
   selector:
     matchLabels:
@@ -24,7 +24,7 @@ spec:
       labels:
         k8s-app: calico-node
         origin: gardener
-        garden.sapcloud.io/role: system-component
+        gardener.cloud/role: system-component
       annotations:
         # This, along with the CriticalAddonsOnly toleration below,
         # marks the pod as a critical add-on, ensuring it gets

--- a/charts/internal/calico/templates/node/rolebinding-garden-psp-calico.yaml
+++ b/charts/internal/calico/templates/node/rolebinding-garden-psp-calico.yaml
@@ -2,12 +2,12 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding
 metadata:
-  name: garden.sapcloud.io:psp:calico
+  name: gardener.cloud:psp:calico
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: garden.sapcloud.io:psp:kube-system:calico
+  name: gardener.cloud:psp:kube-system:calico
 subjects:
 - kind: ServiceAccount
   name: calico-node

--- a/charts/internal/calico/templates/typha/clusterrole-garden-psp-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/clusterrole-garden-psp-calico-typha.yaml
@@ -3,7 +3,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: garden.sapcloud.io:psp:kube-system:calico-typha
+  name: gardener.cloud:psp:kube-system:calico-typha
 rules:
 - apiGroups:
   - policy

--- a/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     origin: gardener
     k8s-app: calico-typha
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
 spec:
   revisionHistoryLimit: 0
   strategy:
@@ -37,7 +37,7 @@ spec:
     metadata:
       labels:
         origin: gardener
-        garden.sapcloud.io/role: system-component
+        gardener.cloud/role: system-component
         k8s-app: calico-typha
       annotations:
         # This, along with the CriticalAddonsOnly toleration below, marks the pod as a critical

--- a/charts/internal/calico/templates/typha/rolebinding-garden-psp-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/rolebinding-garden-psp-calico-typha.yaml
@@ -3,12 +3,12 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding
 metadata:
-  name: garden.sapcloud.io:psp:calico-typha
+  name: gardener.cloud:psp:calico-typha
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: garden.sapcloud.io:psp:kube-system:calico-typha
+  name: gardener.cloud:psp:kube-system:calico-typha
 subjects:
 - kind: ServiceAccount
   name: calico-typha


### PR DESCRIPTION
**What this PR does / why we need it**:
Adapt role label and RBAC naming to the new API group.

**Which issue(s) this PR fixes**:
Ref gardener/gardener/issues/1649.

**Special notes for your reviewer**:
I think it should be backwards compatible adapting directly the role label with regards to the usage from Gardener.
Basically during the Shoot deletion flow, the cleanup selector for system components is `garden.sapcloud.io/role!=system-component,shoot.gardener.cloud/no-cleanup!=true`. The calico ManagedResource is reconciled with injectLabels `shoot.gardener.cloud/no-cleanup=true`. Hence, the calico components even with the new `gardener.cloud/role` label should not be selected by the cleanup selector.
Also for the component healthchecks - the condition of the ManagedResource are used.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
