### PR TITLE
Increase calico-node limits

### DIFF
--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -173,10 +173,10 @@ spec:
             privileged: true
           resources:
             requests:
-              cpu: 100m
+              cpu: 250m
               memory: 100Mi
             limits:
-              cpu: 500m
+              cpu: 800m
               memory: 700Mi
           livenessProbe:
             httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase the limits for calico-node daemonset. 

cc @ialidzhikov 

**Which issue(s) this PR fixes**:
Fixes #13 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Calico requests and limits are now increased to avoid resource starvation. 
```
