### PR TITLE
raise calico-node cpu limits to survive setups without bird and ~150+…

### DIFF
--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -178,7 +178,7 @@ spec:
               cpu: 250m
               memory: 100Mi
             limits:
-              cpu: 800m
+              cpu: 4000m
               memory: 700Mi
           livenessProbe:
             exec:


### PR DESCRIPTION
… pods per node

Running calico-node in a setup without bird, 800m cpu limit is hit quite often and keeps lots of conntrack commands stay stuck for ~20sec. This brings the calico-node pod in unhealthy state as healtcheck and liveliness check will not succeed.

Can we use this PR just to create the image please ?