### PR TITLE
Update calico-cpvpa image again to k8s.gcr.io domain

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -25,5 +25,5 @@ images:
   tag: 1.7.1
 - name: calico-cpva
   sourceRepository: github.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler
-  repository: eu.gcr.io/k8s-artifacts-prod/cpa/cpvpa-amd64
+  repository: k8s.gcr.io/cpvpa-amd64
   tag: v0.8.2


### PR DESCRIPTION
**What this PR does / why we need it**:
calico-cpvpa image is again available under k8s.gcr.io domain. Ref https://github.com/kubernetes/kubernetes/pull/90093#issuecomment-620140609.
We can avoid specifying region-specific image.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
