### PR TITLE
Bump version to mitigatte MiM attack

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,23 +2,23 @@ images:
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
   repository: quay.io/calico/node
-  tag: v3.13.1
+  tag: v3.13.4
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
   repository: quay.io/calico/cni
-  tag: v3.13.1
+  tag: v3.13.4
 - name: calico-typha
   sourceRepository: github.com/projectcalico/typha
   repository: quay.io/calico/typha
-  tag: v3.13.1
+  tag: v3.13.4
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers
   repository: quay.io/calico/kube-controllers
-  tag: v3.13.1
+  tag: v3.13.4
 - name: calico-podtodaemon-flex
   sourceRepository: github.com/projectcalico/pod2daemon
   repository: quay.io/calico/pod2daemon-flexvol
-  tag: v3.13.1
+  tag: v3.13.4
 - name: calico-cpa
   sourceRepository: github.com/kubernetes-sigs/cluster-proportional-autoscaler
   repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64


### PR DESCRIPTION
**How to categorize this PR?**

/area security
/priority critical


**What this PR does / why we need it**:

Bump calico to mitigate MiM attack with IPv6 advertisements: https://www.projectcalico.org/security-bulletins/

**Special notes for your reviewer**:

**Release note**:

```improvement operator
Bump Calico to version 3.13.4
```
