### PR TITLE
Restore now calls Reconcile instead of being an empty op

### DIFF
--- a/pkg/controller/actuator_migrate.go
+++ b/pkg/controller/actuator_migrate.go
@@ -23,5 +23,5 @@ import (
 
 // Migrate implements Network.Actuator.
 func (a *actuator) Migrate(ctx context.Context, network *extensionsv1alpha1.Network, cluster *extensionscontroller.Cluster) error {
-	return a.Delete(ctx, network, cluster)
+	return nil
 }

--- a/pkg/controller/actuator_restore.go
+++ b/pkg/controller/actuator_restore.go
@@ -23,5 +23,5 @@ import (
 
 // Restore implements Network.Actuator.
 func (a *actuator) Restore(ctx context.Context, network *extensionsv1alpha1.Network, cluster *extensionscontroller.Cluster) error {
-	return nil
+	return a.Reconcile(ctx, network, cluster)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area control-plane-migration
/kind task
/priority normal


**What this PR does / why we need it**:
Makes the Restore operation call Reconcile instead of just returning nil.
Also made the Migrate() operation only return nil as otherwise network managed resources can be deleted. Currently the logic to clean up all managed resources without deleting the corresponding objects from the shoot is part of the gardenlet migration flow.

**Which issue(s) this PR fixes**:
Part of [#1631](https://github.com/gardener/gardener/issues/1631)

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Restore now calls reconcile instead of just returning nil.
```
