### PR TITLE
Fix worker annotations for system-components

### DIFF
--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -395,7 +395,7 @@ var _ = Describe("Chart package test", func() {
 					},
 				},
 				"nodeSelector": map[string]string{
-					"worker.gardener.cloud/system-components": "True",
+					"worker.gardener.cloud/system-components": "true",
 				},
 			}))
 		})

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -17,6 +17,7 @@ package charts
 import (
 	"encoding/json"
 	"fmt"
+
 	gardenv1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 
 	calicov1alpha1 "github.com/gardener/gardener-extension-networking-calico/pkg/apis/calico/v1alpha1"
@@ -139,7 +140,7 @@ func ComputeCalicoChartValues(network *extensionsv1alpha1.Network, config *calic
 
 	if workerSystemComponentsActivated {
 		calicoChartValues["nodeSelector"] = map[string]string{
-			gardenv1beta1constants.LabelWorkerPoolSystemComponents: "True",
+			gardenv1beta1constants.LabelWorkerPoolSystemComponents: "true",
 		}
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/priority high
/area networking

**What this PR does / why we need it**:
This PR fixes a regression introduced by https://github.com/gardener/gardener-extension-networking-calico/pull/39/files which used the wrong value for the system-components annotation. 

`worker.gardener.cloud/system-components=True` instead of `worker.gardener.cloud/system-components=true` 
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The correct annotations are now used for system-components. 
```
