### PR TITLE
Remove explicit scrape interval config

### DIFF
--- a/charts/internal/calico-monitoring/templates/calico-monitoring-config.yaml
+++ b/charts/internal/calico-monitoring/templates/calico-monitoring-config.yaml
@@ -8,7 +8,6 @@ metadata:
 data:
   scrape_config: |
     - job_name: 'felix-metrics'
-      scrape_interval: 5s
       scheme: https
       tls_config:
         # This is needed because the kubelets' certificates are not are generated
@@ -30,7 +29,6 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/namespaces/kube-system/pods/${1}:9091/proxy/metrics
     - job_name: 'typha-metrics'
-      scrape_interval: 5s
       scheme: https
       tls_config:
         # This is needed because the kubelets' certificates are not are generated


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug
/priority normal
/area networking

**What this PR does / why we need it**:
This PR remove the explicit setting of the scrape interval, this defaulting the value to 1m. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Scrape interval is defaulted to 1m
```
