### PR TITLE
Fix PSP for the new calico version

### DIFF
--- a/charts/internal/calico/templates/node/psp-calico.yaml
+++ b/charts/internal/calico/templates/node/psp-calico.yaml
@@ -24,6 +24,9 @@ spec:
   - pathPrefix: /var/run/nodeagent
   - pathPrefix: /usr/libexec
   - pathPrefix: /var/lib/kubelet/volumeplugins/nodeagent~uds
+  {{- if semverCompare ">= 1.16" .Capabilities.KubeVersion.GitVersion  }}
+  - pathPrefix: /sys/fs/
+  {{- end }}
   runAsUser:
     rule: RunAsAny
   seLinux:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/priority normal
/area networking

**What this PR does / why we need it**:
Fix PSP after calico update #59 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fix a bug in calico pod security policies that was preventing node bootstrap for shoot with disabled privileged mode. 
```
