### PR TITLE
Use Default DNSPolicy for controllers

### DIFF
--- a/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
@@ -50,6 +50,8 @@ spec:
         operator: Exists
       serviceAccountName: calico-kube-controllers
       priorityClassName: system-cluster-critical
+      # Make sure to not use the coredns for DNS resolution.
+      dnsPolicy: Default
       hostIPC: false
       hostNetwork: false
       hostPID: false

--- a/charts/internal/calico/templates/node-cpva/deployment-calico-node-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/node-cpva/deployment-calico-node-vertical-autoscaler.yaml
@@ -29,6 +29,8 @@ spec:
       priorityClassName: system-cluster-critical
       securityContext:
         runAsUser: 65534
+      # Make sure to not use the coredns for DNS resolution.
+      dnsPolicy: Default
       containers:
         - image:  {{ index .Values.images "calico-cpva" }}
           name: autoscaler

--- a/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
@@ -29,6 +29,8 @@ spec:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       {{- end }}
       priorityClassName: system-cluster-critical
+      # Make sure to not use the coredns for DNS resolution.
+      dnsPolicy: Default
       securityContext:
         supplementalGroups: [ 65534 ]
         fsGroup: 65534

--- a/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
@@ -29,6 +29,8 @@ spec:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       {{- end }}
       priorityClassName: system-cluster-critical
+      # Make sure to not use the coredns for DNS resolution.
+      dnsPolicy: Default
       securityContext:
         runAsUser: 65534
       containers:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement 
/priority normal

**What this PR does / why we need it**:

Those controllers are not part of the host network and do not need to talk to any kubernetes services.

**Which issue(s) this PR fixes**:

Related PR https://github.com/gardener/gardener/pull/3211

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`calico-kube-controllers`, `calico-node-vertical-autoscaller`, `calico-typha-horizontal-autoscaler` and `calico-typha-vertical-autoscaler` now have `dnsPolicy: Default`.
```

/assign @DockToFuture 