### PR TITLE
Configure calico to use autodetection method cidr

### DIFF
--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -159,10 +159,12 @@ spec:
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
             # Auto-detect the BGP IP address.
+            {{- if semverCompare ">= 1.16" .Capabilities.KubeVersion.GitVersion  }}
             {{- if .Values.config.ipv4.autoDetectionMethod }}
             # On metal the ip is bound to the lo interface (routing to the host).
             - name: IP_AUTODETECTION_METHOD
               value: "{{ .Values.config.ipv4.autoDetectionMethod }}"
+            {{- end }}
             {{- end }}
             - name: IP
               value: "autodetect"

--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 
@@ -100,6 +101,14 @@ func (a *actuator) Reconcile(ctx context.Context, network *extensionsv1alpha1.Ne
 		if err != nil {
 			return err
 		}
+	}
+
+	if cluster.Shoot.Spec.Networking.Nodes != nil && len(*cluster.Shoot.Spec.Networking.Nodes) > 0 {
+		autodetectionMode := fmt.Sprintf("cidr=%s", *cluster.Shoot.Spec.Networking.Nodes)
+		if networkConfig == nil {
+			networkConfig = &calicov1alpha1.NetworkConfig{IPv4: &calicov1alpha1.IPv4{}}
+		}
+		networkConfig.IPv4.AutoDetectionMethod = &autodetectionMode
 	}
 
 	// Create shoot chart renderer


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Configure calico to use `IP_AUTODETECTION_METHOD=cidr=cidrRange`

**Which issue(s) this PR fixes**:
Calico uses by default (`IP_AUTODETECTION_METHOD=first-found`) the first found interface on the node, when there are custom interfaces it is possible that they are detected before the actual interface and thus resulting in a broken cluster.
Therefore is `IP_AUTODETECTION_METHOD` switched to `cidr`  mode with the corresponding node cidr from the shoot object to prevent the usage of the wrong interfaces. 


/cc: @ScheererJ @mandelsoft 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Calico is configured to use `IP_AUTODETECTION_METHOD=cidr=cidrRange` with the nodeCidr as cidrRange to prevent the using the wrong interface on the node.
```
