### PR TITLE
do not disable kubeController with backend none

### DIFF
--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -209,7 +209,7 @@ var _ = Describe("Chart package test", func() {
 						"enabled": trueVar,
 					},
 					"kubeControllers": map[string]interface{}{
-						"enabled": falseVar,
+						"enabled": trueVar,
 					},
 					"veth_mtu": defaultMtu,
 					"monitoring": map[string]interface{}{

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -176,7 +176,6 @@ func generateChartValues(config *calicov1alpha1.NetworkConfig) (*calicoConfig, e
 		}
 	}
 	if c.Backend == calicov1alpha1.None {
-		c.KubeControllers.Enabled = false
 		c.Felix.IPInIP.Enabled = false
 		c.IPv4.Mode = calicov1alpha1.Never
 	}


### PR DESCRIPTION
/area networking
/kind TODO
/priority normal

**What this PR does / why we need it**:

Currently setting `backend` to `none` in the shoot.spec disables the calico-kube-controllers: https://github.com/gardener/gardener-extension-networking-calico/blob/master/pkg/charts/utils.go#L178-L182

This even overrules the explicit setting of `kubeControllers.enabled: true`

This PR removes this behavior and therefore allows shoots with `backend: none` to have calico-kube-controllers installed.

Users of gardener-extension-networking-calico with `backend: none` who do not want kubeControllers enabled, should disable kubeControllers (`kubeControllers.enabled: false`) in the shoot spec.

**Special notes for your reviewer**:

Attention: this changes the default behavior for clusters with `backend: none`. Cluster-admins who wish to have kubeControllers disabled should make sure, that kubeControllers.enabled is set to false before upgrading. (Clusters with any other backend (bird, vxlan) are unaffected.)

**Release note**:
Allow enabling of calico-kube-controllers for clusters with `backend: none`
**Attention**: this changes the default behavior for clusters with `backend: none`. Cluster-admins who wish to have kubeControllers disabled should make sure, that kubeControllers.enabled is set to false before upgrading. (Clusters with any other backend (bird, vxlan) are unaffected.)

<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
