### PR TITLE
Add vpa for calico-kube-controllers

### DIFF
--- a/charts/internal/calico/templates/kube-controller/vpa.yaml
+++ b/charts/internal/calico/templates/kube-controller/vpa.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: "autoscaling.k8s.io/v1beta2"
+kind: VerticalPodAutoscaler
+metadata:
+  name: calico-kube-controllers
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: calico-kube-controllers
+  updatePolicy:
+    updateMode: "Auto"
+{{- end }}

--- a/charts/internal/calico/values.yaml
+++ b/charts/internal/calico/values.yaml
@@ -30,4 +30,7 @@ images:
   calico-cpva: "image-repository:image-tag"
   calico-cpa: "image-repository:image-tag"
 
+vpa:
+  enabled: false
+
 # nodeSelector: {}

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -127,7 +127,7 @@ func (c *calicoConfig) toMap() (map[string]interface{}, error) {
 }
 
 // ComputeCalicoChartValues computes the values for the calico chart.
-func ComputeCalicoChartValues(network *extensionsv1alpha1.Network, config *calicov1alpha1.NetworkConfig, workerSystemComponentsActivated bool, kubernetesVersion string) (map[string]interface{}, error) {
+func ComputeCalicoChartValues(network *extensionsv1alpha1.Network, config *calicov1alpha1.NetworkConfig, workerSystemComponentsActivated bool, kubernetesVersion string, wantsVPA bool) (map[string]interface{}, error) {
 	typedConfig, err := generateChartValues(config)
 	if err != nil {
 		return nil, fmt.Errorf("error when generating calico config: %v", err)
@@ -137,6 +137,9 @@ func ComputeCalicoChartValues(network *extensionsv1alpha1.Network, config *calic
 		return nil, fmt.Errorf("could not convert calico config: %v", err)
 	}
 	calicoChartValues := map[string]interface{}{
+		"vpa": map[string]interface{}{
+			"enabled": wantsVPA,
+		},
 		"images": map[string]interface{}{
 			calico.CNIImageName:                                   imagevector.CalicoCNIImage(kubernetesVersion),
 			calico.TyphaImageName:                                 imagevector.CalicoTyphaImage(kubernetesVersion),

--- a/pkg/charts/values.go
+++ b/pkg/charts/values.go
@@ -26,8 +26,8 @@ import (
 const CalicoConfigKey = "config.yaml"
 
 // RenderCalicoChart renders the calico chart with the given values.
-func RenderCalicoChart(renderer chartrenderer.Interface, network *extensionsv1alpha1.Network, config *calicov1alpha1.NetworkConfig, workerSystemComponentsActivated bool, kubernetesVersion string) ([]byte, error) {
-	values, err := ComputeCalicoChartValues(network, config, workerSystemComponentsActivated, kubernetesVersion)
+func RenderCalicoChart(renderer chartrenderer.Interface, network *extensionsv1alpha1.Network, config *calicov1alpha1.NetworkConfig, workerSystemComponentsActivated bool, kubernetesVersion string, wantsVPA bool) ([]byte, error) {
+	values, err := ComputeCalicoChartValues(network, config, workerSystemComponentsActivated, kubernetesVersion, wantsVPA)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -120,7 +120,7 @@ func (a *actuator) Reconcile(ctx context.Context, network *extensionsv1alpha1.Ne
 		return errors.Wrapf(err, "could not create chart renderer for shoot '%s'", network.Namespace)
 	}
 
-	calicoChart, err := charts.RenderCalicoChart(chartRenderer, network, networkConfig, activateSystemComponentsNodeSelector(cluster.Shoot), cluster.Shoot.Spec.Kubernetes.Version)
+	calicoChart, err := charts.RenderCalicoChart(chartRenderer, network, networkConfig, activateSystemComponentsNodeSelector(cluster.Shoot), cluster.Shoot.Spec.Kubernetes.Version, gardencorev1beta1helper.ShootWantsVerticalPodAutoscaler(cluster.Shoot))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Add vpa for calico-kube-controllers.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Does not include a min-allowed value for the VPA 
There is no particular reason for it, it is just that I do not have sufficient experience to know what minimum resources the calico-kube-controllers deployment requires.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add VPA for calico-kube-controllers deployment.
```
