### PR TITLE
Added simple init container to calico-node to verify that the cni installation step worked.

### DIFF
--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -107,6 +107,16 @@ spec:
             mountPath: /host/driver
         securityContext:
           privileged: true
+      # Container just prints the content of the host /opt/cni/bin directory to check for copy failures
+      - name: install-cni-check
+        image: {{ index .Values.images "calico-podtodaemon-flex" }}
+        command:
+          - ls
+          - -la
+          - /host/opt/cni/bin
+        volumeMounts:
+          - mountPath: /host/opt/cni/bin
+            name: cni-bin-dir
       containers:
         # Runs calico-node container on each Kubernetes node. This
         # container programs network policy and routes on each


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
As #70 is not reproducible, this pull request tries to validate the init container cni installation step within another init container.

**Which issue(s) this PR fixes**:
Added tracing to get more details regarding #70 .

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
