### PR TITLE
Updated calico to 3.18.2.

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
   repository: docker.io/calico/node
-  tag: v3.18.1
+  tag: v3.18.2
   targetVersion: ">= 1.16"
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
@@ -12,7 +12,7 @@ images:
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
   repository: docker.io/calico/cni
-  tag: v3.18.1
+  tag: v3.18.2
   targetVersion: ">= 1.16"
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
@@ -22,7 +22,7 @@ images:
 - name: calico-typha
   sourceRepository: github.com/projectcalico/typha
   repository: docker.io/calico/typha
-  tag: v3.18.1
+  tag: v3.18.2
   targetVersion: ">= 1.16"
 - name: calico-typha
   sourceRepository: github.com/projectcalico/typha
@@ -32,7 +32,7 @@ images:
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers
   repository: docker.io/calico/kube-controllers
-  tag: v3.18.1
+  tag: v3.18.2
   targetVersion: ">= 1.16"
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers
@@ -42,7 +42,7 @@ images:
 - name: calico-podtodaemon-flex
   sourceRepository: github.com/projectcalico/pod2daemon
   repository: docker.io/calico/pod2daemon-flexvol
-  tag: v3.18.1
+  tag: v3.18.2
   targetVersion: ">= 1.16"
 - name: calico-podtodaemon-flex
   sourceRepository: github.com/projectcalico/pod2daemon

--- a/charts/internal/calico/templates/custom-resource-definition/crd-bgppeers.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-bgppeers.yaml
@@ -22,7 +22,6 @@ metadata:
   name: bgppeers.crd.projectcalico.org
   labels:
     gardener.cloud/role: system-component
-  name: bgppeers.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
   names:

--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -67,6 +67,13 @@ spec:
         {{- else}}
         command: ["/opt/cni/bin/install"]
         {{- end }}
+        {{- if semverCompare ">= 1.16" .Capabilities.KubeVersion.GitVersion  }}
+        envFrom:
+        - configMapRef:
+            # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
+            name: kubernetes-services-endpoint
+            optional: true
+        {{- end }}
         env:
           # Name of the CNI config file to create.
           - name: CNI_CONF_NAME


### PR DESCRIPTION
In addition to that fixed two minor issues (redundant name declaration and missing env variable for ebpf mode).

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Updates calico to 3.18.2.

**Which issue(s) this PR fixes**:
See https://docs.projectcalico.org/archive/v3.18/release-notes/

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Updated calico to 3.18.2.
```
