### PR TITLE
Added usage of secondary-cni-dir to workaround random cni installation issues

### DIFF
--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -103,6 +103,8 @@ spec:
             name: cni-bin-dir
           - mountPath: /host/etc/cni/net.d
             name: cni-net-dir
+          - mountPath: /host/secondary-bin-dir
+            name: cni-bin-dir
         securityContext:
           privileged: true
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
We have seen some rare cases where the cni installation seem to succeed, but the calico cni binaries are missing afterwards. This renders the node unusable as no new containers can be created. The workaround is to delete the calico-node pod to trigger the cni installation again.
This pull requests mounts the cni binary directory /opt/cni/bin a second time inside the install-cni container. The cni install container now effectively copies the cni binaries twice hopefully increasing the chance that the binaries will actually get copied or providing more insights into the issue.

**Which issue(s) this PR fixes**:
This is kind of a workaround for the calico cni installation issues.

**Special notes for your reviewer**:
Tested with kubernetes 1.20.6 and 1.15.12.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
