### PR TITLE
Only use secondary bin dir during cni installation

### DIFF
--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -99,8 +99,8 @@ spec:
           - name: SLEEP
             value: "false"
         volumeMounts:
-          - mountPath: /host/opt/cni/bin
-            name: cni-bin-dir
+          #- mountPath: /host/opt/cni/bin
+          #  name: cni-bin-dir
           - mountPath: /host/etc/cni/net.d
             name: cni-net-dir
           - mountPath: /host/secondary-bin-dir


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
The pull request disables the usage of the primary cni binary directory during the cni installation. The cni installer removes the calico binaries from that directory. To ensure that this never happens for us we switch to the exclusive use of the secondary cni bin directory.

**Which issue(s) this PR fixes**:
Might fix #70, but this is a long shot.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
