### PR TITLE
Enabled automatic management of the kubeconfig used by the cni operations

### DIFF
--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -243,6 +243,9 @@ spec:
             # Limit NAT port range: https://github.com/projectcalico/felix/pull/1838
             - name: FELIX_NATPORTRANGE
               value: "32768:65535"
+            # Enable automatic management of kubeconfig used by CNI (required due to limited lifetime of service account tokens, default in starting with kubernetes v1.21, BoundServiceAccountTokenVolume feature)
+            - name: CALICO_MANAGE_CNI
+              value: "true"
           securityContext:
             privileged: true
           resources:
@@ -299,6 +302,9 @@ spec:
               mountPath: /var/log/calico/cni
               readOnly: true
               {{- end }}
+            # Needed for managing the kubeconfig used by CNI (CALICO_MANAGE_CNI=true)
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
       volumes:
         # Used by calico/node.
         - name: lib-modules


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Starting with kubernetes v1.21 service account tokens have a limited life time per default (BoundServiceAccountTokenVolume feature). Therefore, it is not sufficient to simply take the service account token during the init container of calico node and use it happily ever after. This change enables the automatic management by calico, i.e. if the service account token changes the cni kubeconfig will be updated automatically.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The kubeconfig used by cni (/etc/cni/net.d/calico-kubeconfig) will be automatically updated if the service account token changes.
```
