### PR TITLE
drop support for k8s <v1.15.0

### DIFF
--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -38,11 +38,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       nodeSelector:
-        {{- if semverCompare "<= 1.14-0" .Capabilities.KubeVersion.GitVersion }}
-        beta.kubernetes.io/os: linux
-        {{- else }}
         kubernetes.io/os: linux
-        {{- end  }}
       hostNetwork: true
       tolerations:
         # Make sure calico-node gets scheduled on all nodes.

--- a/charts/utils-templates/templates/_versions.tpl
+++ b/charts/utils-templates/templates/_versions.tpl
@@ -3,11 +3,7 @@ kubelet.config.k8s.io/v1beta1
 {{- end -}}
 
 {{- define "schedulercomponentconfigversion" -}}
-{{- if semverCompare ">= 1.12-0" .Capabilities.KubeVersion.GitVersion -}}
 kubescheduler.config.k8s.io/v1alpha1
-{{- else -}}
-componentconfig/v1alpha1
-{{- end -}}
 {{- end -}}
 
 {{- define "proxycomponentconfigversion" -}}
@@ -19,11 +15,7 @@ apiserver.k8s.io/v1alpha1
 {{- end -}}
 
 {{- define "auditkubernetesversion" -}}
-{{- if semverCompare ">= 1.12-0" .Capabilities.KubeVersion.GitVersion -}}
 audit.k8s.io/v1
-{{- else -}}
-audit.k8s.io/v1beta1
-{{- end -}}
 {{- end -}}
 
 {{- define "rbacversion" -}}
@@ -71,17 +63,9 @@ policy/v1beta1
 {{- end -}}
 
 {{- define "ingressversion" -}}
-{{- if semverCompare ">= 1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 networking.k8s.io/v1beta1
-{{- else -}}
-extensions/v1beta1
-{{- end -}}
 {{- end -}}
 
 {{- define "storageclassversion" -}}
-{{- if semverCompare ">= 1.13-0" .Capabilities.KubeVersion.GitVersion -}}
 storage.k8s.io/v1
-{{- else -}}
-storage.k8s.io/v1beta1
-{{- end -}}
 {{- end -}}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
Drop support for `k8s<v1.15.0`as it was already dropped in Gardener https://github.com/gardener/gardener/pull/3862.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Drop support for `k8s<v1.15.0`.
```
