### PR TITLE
Do not check the Seed K8s version for a supported K8s version

### DIFF
--- a/pkg/controller/actuator.go
+++ b/pkg/controller/actuator.go
@@ -45,8 +45,7 @@ type actuator struct {
 
 	client client.Client
 
-	gardenerClientset gardenerkubernetes.Interface
-	chartApplier      gardenerkubernetes.ChartApplier
+	chartApplier gardenerkubernetes.ChartApplier
 }
 
 const LogID = "network-calico-actuator"
@@ -68,11 +67,9 @@ func (a *actuator) InjectConfig(config *rest.Config) error {
 	a.restConfig = config
 
 	var err error
-	a.gardenerClientset, err = gardenerkubernetes.NewWithConfig(gardenerkubernetes.WithRESTConfig(config))
+	a.chartApplier, err = gardenerkubernetes.NewChartApplierForConfig(config)
 	if err != nil {
-		return fmt.Errorf("could not create Gardener client: %w", err)
+		return fmt.Errorf("could not create ChartApplier: %w", err)
 	}
-
-	a.chartApplier = a.gardenerClientset.ChartApplier()
 	return nil
 }


### PR DESCRIPTION
/area networking
/kind enhancement

Currently networking-calico@v1.19.0 fails to start on K8s v1.22.x Seed with:

```
{"level":"error","ts":1631882899.1693969,"msg":"Could not add controllers to manager","error":"could not create Gardener client: error discovering kubernetes version: unsupported kubernetes version \"v1.22.2\"","errorVerbose":"error discovering kubernetes version: unsupported kubernetes version \"v1.22.2\"\ncould not create Gardener client\n<omitted>}
```

Similar issue was also observed in the past for networking-cilium - ref https://github.com/gardener/gardener-extension-networking-cilium/issues/42.

In more details:
networking-calico uses a ChartApplier to apply the `calico-monitoring-config` chart in the Shoot namespace in the Seed.
Currently in order to create a ChartApplier, the extension creates a `pkg/client/kubernetes.clientSet` (via `pkg/client/kubernetes.NewWithConfig`) and then gets the ChartApplier from the gardener clientSet.
https://github.com/gardener/gardener-extension-networking-calico/blob/4680398614665a0c2b4d7f96ccc8e3ca9c24d174/pkg/controller/actuator.go#L67-L78

The problem with this approach is that `pkg/client/kubernetes.NewWithConfig` internally checks whether the server version is a supported one against a list of hard-coded supported versions. This causes the extension to fail to start on new K8s versions when the corresponding `github.com/gardener/gardener` dependency is not updated/vendored (that brings the list with the updated supported K8s versions).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The extension does no longer depend on a list of supported Kubernetes versions (coming from the `github.com/gardener/gardener` dependency). This was preventing the extension to start against Seed clusters running on K8s versions that were not present in the mentioned list.
```
