### PR TITLE
[release-v1.19] Automated cherry pick of #111: Do not check the Seed K8s version for a supported K8s version

### DIFF
--- a/pkg/controller/actuator.go
+++ b/pkg/controller/actuator.go
@@ -44,8 +44,7 @@ type actuator struct {
 
 	client client.Client
 
-	gardenerClientset gardenerkubernetes.Interface
-	chartApplier      gardenerkubernetes.ChartApplier
+	chartApplier gardenerkubernetes.ChartApplier
 }
 
 const LogID = "network-calico-actuator"
@@ -67,11 +66,9 @@ func (a *actuator) InjectConfig(config *rest.Config) error {
 	a.restConfig = config
 
 	var err error
-	a.gardenerClientset, err = gardenerkubernetes.NewWithConfig(gardenerkubernetes.WithRESTConfig(config))
+	a.chartApplier, err = gardenerkubernetes.NewChartApplierForConfig(config)
 	if err != nil {
-		return errors.Wrap(err, "could not create Gardener client")
+		return errors.Wrap(err, "could not create ChartApplier")
 	}
-
-	a.chartApplier = a.gardenerClientset.ChartApplier()
 	return nil
 }


### PR DESCRIPTION
/area/networking
/kind/enhancement

Cherry pick of #111 on release-v1.19.

#111: Do not check the Seed K8s version for a supported K8s version

**Release Notes:**
```other operator
The extension does no longer depend on a list of supported Kubernetes versions (coming from the `github.com/gardener/gardener` dependency). This was preventing the extension to start against Seed clusters running on K8s versions that were not present in the mentioned list.
```