### PR TITLE
Updated to calico 3.20.1.

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
   repository: docker.io/calico/node
-  tag: v3.20.0
+  tag: v3.20.1
   targetVersion: ">= 1.16"
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
@@ -12,7 +12,7 @@ images:
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
   repository: docker.io/calico/cni
-  tag: v3.20.0
+  tag: v3.20.1
   targetVersion: ">= 1.16"
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
@@ -22,7 +22,7 @@ images:
 - name: calico-typha
   sourceRepository: github.com/projectcalico/typha
   repository: docker.io/calico/typha
-  tag: v3.20.0
+  tag: v3.20.1
   targetVersion: ">= 1.16"
   labels:
   - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
@@ -42,7 +42,7 @@ images:
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers
   repository: docker.io/calico/kube-controllers
-  tag: v3.20.0
+  tag: v3.20.1
   targetVersion: ">= 1.16"
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers
@@ -52,7 +52,7 @@ images:
 - name: calico-podtodaemon-flex
   sourceRepository: github.com/projectcalico/pod2daemon
   repository: docker.io/calico/pod2daemon-flexvol
-  tag: v3.20.0
+  tag: v3.20.1
   targetVersion: ">= 1.16"
 - name: calico-podtodaemon-flex
   sourceRepository: github.com/projectcalico/pod2daemon

--- a/charts/internal/calico/templates/custom-resource-definition/crd-networkpolicies.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-networkpolicies.yaml
@@ -19,7 +19,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: null
   name: networkpolicies.crd.projectcalico.org
   labels:
     gardener.cloud/role: system-component

--- a/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
@@ -15,12 +15,12 @@ metadata:
     scheduler.alpha.kubernetes.io/critical-pod: ''
   {{- end }}
 spec:
+  # The controllers can only have a single active instance.
+  replicas: 1
   revisionHistoryLimit: 0
   selector:
     matchLabels:
       k8s-app: calico-kube-controllers
-  # The controller can only have a single active instance.
-  replicas: 1
   strategy:
     type: Recreate
   template:

--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -2,8 +2,8 @@
 # This manifest installs the calico/node container, as well
 # as the Calico CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
-apiVersion: {{ include "daemonsetversion" . }}
 kind: DaemonSet
+apiVersion: {{ include "daemonsetversion" . }}
 metadata:
   name: calico-node
   namespace: kube-system
@@ -36,7 +36,6 @@ spec:
         {{- end }}
         checksum/configmap-calico: {{ include (print $.Template.BasePath "/node/configmap-calico-config.yaml") . | sha256sum }}
     spec:
-      priorityClassName: system-node-critical
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true
@@ -53,8 +52,9 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
+      priorityClassName: system-node-critical
       initContainers:
-      # This container installs the Calico CNI binaries
+      # This container installs the CNI binaries
       # and CNI network config file on each node.
       - name: install-cni
         image: {{ index .Values.images "calico-cni" }}
@@ -164,15 +164,23 @@ spec:
             # Enable felix info logging.
             - name: FELIX_LOGSEVERITYSCREEN
               value: "error"
+            # Wait for the datastore.
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            # Set based on the k8s node name.
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Choose the backend to use.
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
               value: "k8s,bgp"
-            # Disable file logging so `kubectl logs` works.
-            - name: CALICO_DISABLE_FILE_LOGGING
-              value: "true"
-            # Set Felix endpoint to host default action to ACCEPT.
-            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
-              value: "ACCEPT"
             # Auto-detect the BGP IP address.
             {{- if semverCompare ">= 1.16" .Capabilities.KubeVersion.GitVersion  }}
             {{- if .Values.config.ipv4.autoDetectionMethod }}
@@ -183,9 +191,6 @@ spec:
             {{- end }}
             - name: IP
               value: "autodetect"
-            # Disable IPV6 on Kubernetes.
-            - name: FELIX_IPV6SUPPORT
-              value: "false"
             {{- if semverCompare ">= 1.16" .Capabilities.KubeVersion.GitVersion  }}
             # Enable or Disable VXLAN on the default IP pool.
             - name: CALICO_IPV4POOL_VXLAN
@@ -211,14 +216,20 @@ spec:
                   name: calico-config
                   key: veth_mtu
             {{- end }}
-            # Wait for the datastore.
-            - name: WAIT_FOR_DATASTORE
-              value: "true"
             # The default IPv4 pool to create on startup if none exists. Pod IPs will be
             # chosen from this range. Changing this value after installation will have
             # no effect. This should fall within `--cluster-cidr`.
             - name: CALICO_IPV4POOL_CIDR
               value: "{{ .Values.global.podCIDR }}"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # Disable IPv6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
             - name: FELIX_IPINIPENABLED
               value: "{{ .Values.config.felix.ipinip.enabled }}"
             - name: "CALICO_IPV4POOL_{{ .Values.config.ipv4.pool | upper }}"
@@ -229,17 +240,6 @@ spec:
             # Controls whether Felix will clean up the iptables rules created by the Kubernetes kube-proxy; should only be enabled if kube-proxy is not running.
             - name: FELIX_BPFKUBEPROXYIPTABLESCLEANUPENABLED
               value: "{{ .Values.config.felix.bpfKubeProxyIPTablesCleanup.enabled }}"
-            # Choose the backend to use.
-            - name: CALICO_NETWORKING_BACKEND
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: calico_backend
-            # Set based on the k8s node name.
-            - name: NODENAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             - name: FELIX_HEALTHENABLED
               value: "true"
             # Limit NAT port range: https://github.com/projectcalico/felix/pull/1838
@@ -308,7 +308,7 @@ spec:
               readOnly: true
               {{- end }}
       volumes:
-        # Used by calico/node.
+        # Used by calico-node.
         - name: lib-modules
           hostPath:
             path: /lib/modules

--- a/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
@@ -107,12 +107,12 @@ spec:
             value: "kubernetes"
           - name: TYPHA_HEALTHENABLED
             value: "true"
-          # Uncomment these lines to enable prometheus metrics.  Since Typha is host-networked,
+          # Uncomment these lines to enable prometheus metrics. Since Typha is host-networked,
           # this opens a port on the host, which may need to be secured.
-#          - name: TYPHA_PROMETHEUSMETRICSENABLED
-#            value: "true"
-#          - name: TYPHA_PROMETHEUSMETRICSPORT
-#            value: "9093"
+          #- name: TYPHA_PROMETHEUSMETRICSENABLED
+          #  value: "true"
+          #- name: TYPHA_PROMETHEUSMETRICSPORT
+          #  value: "9093"
         resources:
           requests:
             cpu: 200m
@@ -120,9 +120,6 @@ spec:
           limits:
             cpu: 500m
             memory: 700Mi
-        securityContext:
-          runAsNonRoot: true
-          allowPrivilegeEscalation: false
         livenessProbe:
           httpGet:
             path: /liveness
@@ -131,6 +128,9 @@ spec:
           periodSeconds: 30
           initialDelaySeconds: 30
           timeoutSeconds: 10
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
         readinessProbe:
           httpGet:
             path: /readiness


### PR DESCRIPTION
To reduce the difference between the mainstream calico releases thise change includes minor changes that should have no effect in reality, e.g. reordering of environment variables in manifests, but these changes should make future merge/diff operations more convenient.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
It updates calico to 3.20.1 and reduces the diff so that further updates should be easier.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
