### PR TITLE
update calico to v3.20.2

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
   repository: docker.io/calico/node
-  tag: v3.20.1
+  tag: v3.20.2
   targetVersion: ">= 1.16"
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
@@ -12,7 +12,7 @@ images:
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
   repository: docker.io/calico/cni
-  tag: v3.20.1
+  tag: v3.20.2
   targetVersion: ">= 1.16"
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
@@ -22,7 +22,7 @@ images:
 - name: calico-typha
   sourceRepository: github.com/projectcalico/typha
   repository: docker.io/calico/typha
-  tag: v3.20.1
+  tag: v3.20.2
   targetVersion: ">= 1.16"
   labels:
   - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
@@ -42,7 +42,7 @@ images:
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers
   repository: docker.io/calico/kube-controllers
-  tag: v3.20.1
+  tag: v3.20.2
   targetVersion: ">= 1.16"
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers
@@ -52,7 +52,7 @@ images:
 - name: calico-podtodaemon-flex
   sourceRepository: github.com/projectcalico/pod2daemon
   repository: docker.io/calico/pod2daemon-flexvol
-  tag: v3.20.1
+  tag: v3.20.2
   targetVersion: ">= 1.16"
 - name: calico-podtodaemon-flex
   sourceRepository: github.com/projectcalico/pod2daemon

--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -257,6 +257,12 @@ spec:
             limits:
               cpu: 800m
               memory: 700Mi
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/calico-node
+                - -shutdown
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Update calico to `v3.20.2`. For more information see https://docs.projectcalico.org/release-notes/#v3202.


**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update calico to `v3.20.2`.
```
