### PR TITLE
use calico version 3.20.2 only for k8s cluster > v1.16

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -3,7 +3,12 @@ images:
   sourceRepository: github.com/projectcalico/calico
   repository: docker.io/calico/node
   tag: v3.20.2
-  targetVersion: ">= 1.16"
+  targetVersion: "> 1.16"
+- name: calico-node
+  sourceRepository: github.com/projectcalico/calico
+  repository: docker.io/calico/node
+  tag: v1.19.1
+  targetVersion: "~ 1.16"
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
   repository: quay.io/calico/node
@@ -13,7 +18,12 @@ images:
   sourceRepository: github.com/projectcalico/cni-plugin
   repository: docker.io/calico/cni
   tag: v3.20.2
-  targetVersion: ">= 1.16"
+  targetVersion: "> 1.16"
+- name: calico-cni
+  sourceRepository: github.com/projectcalico/cni-plugin
+  repository: docker.io/calico/cni
+  tag: v1.19.1
+  targetVersion: "~ 1.16"
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
   repository: quay.io/calico/cni
@@ -23,7 +33,17 @@ images:
   sourceRepository: github.com/projectcalico/typha
   repository: docker.io/calico/typha
   tag: v3.20.2
-  targetVersion: ">= 1.16"
+  targetVersion: "> 1.16"
+  labels:
+  - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
+    value:
+      policy: skip
+      comment: payload are two statically linked ELF-binaries and some configuration/license files - not suitable for binary-id-scanning
+- name: calico-typha
+  sourceRepository: github.com/projectcalico/typha
+  repository: docker.io/calico/typha
+  tag: v3.19.1
+  targetVersion: "~ 1.16"
   labels:
   - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
     value:
@@ -43,7 +63,12 @@ images:
   sourceRepository: github.com/projectcalico/kube-controllers
   repository: docker.io/calico/kube-controllers
   tag: v3.20.2
-  targetVersion: ">= 1.16"
+  targetVersion: "> 1.16"
+- name: calico-kube-controllers
+  sourceRepository: github.com/projectcalico/kube-controllers
+  repository: docker.io/calico/kube-controllers
+  tag: v3.19.1
+  targetVersion: "~ 1.16"
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers
   repository: quay.io/calico/kube-controllers
@@ -53,7 +78,12 @@ images:
   sourceRepository: github.com/projectcalico/pod2daemon
   repository: docker.io/calico/pod2daemon-flexvol
   tag: v3.20.2
-  targetVersion: ">= 1.16"
+  targetVersion: "> 1.16"
+- name: calico-podtodaemon-flex
+  sourceRepository: github.com/projectcalico/pod2daemon
+  repository: docker.io/calico/pod2daemon-flexvol
+  tag: v3.19.1
+  targetVersion: "~ 1.16"
 - name: calico-podtodaemon-flex
   sourceRepository: github.com/projectcalico/pod2daemon
   repository: quay.io/calico/pod2daemon-flexvol


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Use calico `v3.20.2` only for k8s cluster > `v1.16`, since it is not compatible with `v1.16` or smaller.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
none
```
