### PR TITLE
Update to calico v3.21.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
   repository: docker.io/calico/node
-  tag: v3.21.0
+  tag: v3.21.1
   targetVersion: ">= 1.17"
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
@@ -17,7 +17,7 @@ images:
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
   repository: docker.io/calico/cni
-  tag: v3.21.0
+  tag: v3.21.1
   targetVersion: ">= 1.17"
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
@@ -32,7 +32,7 @@ images:
 - name: calico-typha
   sourceRepository: github.com/projectcalico/typha
   repository: docker.io/calico/typha
-  tag: v3.21.0
+  tag: v3.21.1
   targetVersion: ">= 1.17"
   labels:
   - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
@@ -62,7 +62,7 @@ images:
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers
   repository: docker.io/calico/kube-controllers
-  tag: v3.21.0
+  tag: v3.21.1
   targetVersion: ">= 1.17"
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers
@@ -77,7 +77,7 @@ images:
 - name: calico-podtodaemon-flex
   sourceRepository: github.com/projectcalico/pod2daemon
   repository: docker.io/calico/pod2daemon-flexvol
-  tag: v3.21.0
+  tag: v3.21.1
   targetVersion: ">= 1.17"
 - name: calico-podtodaemon-flex
   sourceRepository: github.com/projectcalico/pod2daemon


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Contains several bugfixes for calico, for more information see the [release notes](https://docs.projectcalico.org/archive/v3.21/release-notes/).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update calico to `v3.21.1`.
```
