### PR TITLE
add autoscaling for memory to tyhpa deployment

### DIFF
--- a/charts/internal/calico/templates/typha-cpva/configmap-typha-vertical-autoscaling.yaml
+++ b/charts/internal/calico/templates/typha-cpva/configmap-typha-vertical-autoscaling.yaml
@@ -14,7 +14,13 @@ data:
             "base": "120m",
             "step": "80m",
             "nodesPerStep": 10,
-            "max": "1000m"
+            "max": "500m"
+          },
+          "memory": {
+            "base": "100Mi",
+            "step": "40Mi",
+            "nodesPerStep": 10,
+            "max": "2000Mi"
           }
         }
       }

--- a/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
@@ -16,11 +16,12 @@ metadata:
     # if it ever gets evicted.
     scheduler.alpha.kubernetes.io/critical-pod: ''
     cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
+    resources.gardener.cloud/preserve-resources: 'true'
   labels:
     k8s-app: calico-typha
     gardener.cloud/role: system-component
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 5
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Add autoscaling for memory to tyhpa deployment.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add autoscaling for memory to tyhpa deployment.
```
