### PR TITLE
fix autoscaling for node-cpva

### DIFF
--- a/charts/internal/calico/templates/node-cpva/configmap-node-vertical-autoscaling.yaml
+++ b/charts/internal/calico/templates/node-cpva/configmap-node-vertical-autoscaling.yaml
@@ -13,7 +13,7 @@ data:
             "base": "120m",
             "step": "80m",
             "nodesPerStep": 10,
-            "max": "1000m"
+            "max": "800m"
           }
         }
       }

--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -10,6 +10,8 @@ metadata:
   labels:
     k8s-app: calico-node
     gardener.cloud/role: system-component
+  annotations:
+    resources.gardener.cloud/preserve-resources: 'true'
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Co-authored-by: Johannes Scheerer <johannes.scheerer@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Set `resources.gardener.cloud/preserve-resources=true` annotation so that GRM will respect the request values set by `node-cpva`.


**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Set `resources.gardener.cloud/preserve-resources=true` annotation so that GRM will respect the request values set by `node-cpva`.
```
