### PR TITLE
Use default log level info for calico-nodes and set revisionhistorylimit.

### DIFF
--- a/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   # The controllers can only have a single active instance.
   replicas: 1
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       k8s-app: calico-kube-controllers

--- a/charts/internal/calico/templates/node-cpva/deployment-calico-node-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/node-cpva/deployment-calico-node-vertical-autoscaler.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     k8s-app: calico-node-autoscaler
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 5
   replicas: 1
   selector:
     matchLabels:

--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -13,6 +13,7 @@ metadata:
   annotations:
     resources.gardener.cloud/preserve-resources: 'true'
 spec:
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
       k8s-app: calico-node
@@ -153,9 +154,6 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: typha_service_name
-            # Enable felix info logging.
-            - name: FELIX_LOGSEVERITYSCREEN
-              value: "error"
             # Wait for the datastore.
             - name: WAIT_FOR_DATASTORE
               value: "true"

--- a/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     k8s-app: calico-typha-autoscaler
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 5
   replicas: 1
   selector:
     matchLabels:

--- a/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     k8s-app: calico-typha-autoscaler
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 5
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
This allows us to configure the log level at runtime with
felixconfiguration. Default log level for new clusters is changed to 

Co-authored-by: Johannes Scheerer <johannes.scheerer@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
**What this PR does / why we need it**:
Use default log level info for calico-nodes and set revisionhistorylimit to 5.
This allows us to configure the log level at runtime with
felixconfiguration.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Use default log level info for calico-nodes and set revisionhistorylimit to 5.
```
