### PR TITLE
Increased cpu limit of calico typha and memory limit of the calico autoscalers.

### DIFF
--- a/charts/internal/calico/templates/node-cpva/configmap-node-vertical-autoscaling.yaml
+++ b/charts/internal/calico/templates/node-cpva/configmap-node-vertical-autoscaling.yaml
@@ -14,6 +14,26 @@ data:
             "step": "80m",
             "nodesPerStep": 10,
             "max": "800m"
+          },
+          "memory": {
+            "base": "50Mi",
+            "step": "50Mi",
+            "nodesPerStep": 10,
+            "max": "1400Mi"
+          }
+        },
+        "limits": {
+          "cpu": {
+            "base": "320m",
+            "step": "80m",
+            "nodesPerStep": 10,
+            "max": "800m"
+          },
+          "memory": {
+            "base": "650Mi",
+            "step": "50Mi",
+            "nodesPerStep": 10,
+            "max": "1400Mi"
           }
         }
       }

--- a/charts/internal/calico/templates/node-cpva/deployment-calico-node-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/node-cpva/deployment-calico-node-vertical-autoscaler.yaml
@@ -48,7 +48,7 @@ spec:
               memory: 50Mi
             limits:
               cpu: 10m
-              memory: 50Mi
+              memory: 200Mi
           volumeMounts:
             - name: config
               mountPath: /etc/config

--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -246,7 +246,7 @@ spec:
               memory: 100Mi
             limits:
               cpu: 800m
-              memory: 700Mi
+              memory: 1400Mi
           lifecycle:
             preStop:
               exec:

--- a/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
@@ -51,6 +51,6 @@ spec:
               memory: 50Mi
             limits:
               cpu: 10m
-              memory: 50Mi
+              memory: 200Mi
       serviceAccountName: typha-cpha
 {{- end }}

--- a/charts/internal/calico/templates/typha-cpva/configmap-typha-vertical-autoscaling.yaml
+++ b/charts/internal/calico/templates/typha-cpva/configmap-typha-vertical-autoscaling.yaml
@@ -14,11 +14,25 @@ data:
             "base": "120m",
             "step": "80m",
             "nodesPerStep": 10,
-            "max": "500m"
+            "max": "1000m"
           },
           "memory": {
             "base": "100Mi",
             "step": "40Mi",
+            "nodesPerStep": 10,
+            "max": "2000Mi"
+          }
+        },
+        "limits": {
+          "cpu": {
+            "base": "400m",
+            "step": "100m",
+            "nodesPerStep": 10,
+            "max": "1000m"
+          },
+          "memory": {
+            "base": "400Mi",
+            "step": "50Mi",
             "nodesPerStep": 10,
             "max": "2000Mi"
           }

--- a/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
@@ -50,7 +50,7 @@ spec:
               memory: 50Mi
             limits:
               cpu: 10m
-              memory: 50Mi
+              memory: 200Mi
           volumeMounts:
             - name: config
               mountPath: /etc/config

--- a/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
@@ -123,7 +123,7 @@ spec:
             cpu: 200m
             memory: 100Mi
           limits:
-            cpu: 500m
+            cpu: 1000m
             memory: 2000Mi
         livenessProbe:
           httpGet:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
Increased cpu limit of calico typha and memory limit of the calico autoscalers.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Increased cpu limit of calico typha and memory limit of the calico autoscalers.
```
