### PR TITLE
Fixed vpa for calico-kube-controllers being applied even if the target was not deployed

### DIFF
--- a/charts/internal/calico/templates/kube-controller/vpa.yaml
+++ b/charts/internal/calico/templates/kube-controller/vpa.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config.kubeControllers.enabled }}
 {{- if .Values.vpa.enabled }}
 apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
@@ -11,4 +12,5 @@ spec:
     name: calico-kube-controllers
   updatePolicy:
     updateMode: "Auto"
+{{- end }}
 {{- end }}


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Fixed vpa for calico-kube-controllers being applied even if the target was not deployed.

In case no backend is used, calico-kube-controllers is not deployed. Therefore, the corresponding vpa resource should also not be deployed.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Only apply vpa for calico-kube-controllers if calico-kube-controllers is actually deployed.
```
