### PR TITLE
Improve the calico scrape configuration

### DIFF
--- a/charts/internal/calico-monitoring/templates/calico-monitoring-config.yaml
+++ b/charts/internal/calico-monitoring/templates/calico-monitoring-config.yaml
@@ -23,6 +23,8 @@ data:
       kubernetes_sd_configs:
       - role: endpoints
         api_server: https://kube-apiserver:443
+        namespaces:
+          names: [kube-system]
         tls_config:
         {{- if .Values.useProjectedTokenMount }}
           ca_file: /etc/prometheus/seed/ca.crt
@@ -33,15 +35,24 @@ data:
 {{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
         {{- end }}
       relabel_configs:
-      - source_labels: [__meta_kubernetes_service_name]
-        regex: calico-felix-monitoring
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_pod_container_port_name]
+        regex: calico-felix-monitoring;metrics
         action: keep
+      - source_labels: [__meta_kubernetes_endpoint_node_name]
+        target_label: node
+      - source_labels: [__meta_kubernetes_pod_name]
+        target_label: pod
       - target_label: __address__
         replacement: kube-apiserver:443
-      - source_labels: [__meta_kubernetes_pod_name]
-        regex: (.+)
+      - source_labels: [__meta_kubernetes_pod_name, __meta_kubernetes_pod_container_port_number]
+        regex: (.+);(.+)
         target_label: __metrics_path__
-        replacement: /api/v1/namespaces/kube-system/pods/${1}:9091/proxy/metrics
+        replacement: /api/v1/namespaces/kube-system/pods/${1}:${2}/proxy/metrics
+      metric_relabel_configs:
+      - source_labels: [ __name__ ]
+        regex: felix_.+
+        action: keep
+
     - job_name: 'typha-metrics'
       scheme: https
       tls_config:
@@ -58,18 +69,28 @@ data:
       kubernetes_sd_configs:
       - role: endpoints
         api_server: https://kube-apiserver:443
+        namespaces:
+          names: [kube-system]
         tls_config:
 {{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
       relabel_configs:
-      - source_labels: [__meta_kubernetes_service_name]
-        regex: calico-typha-monitoring
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_pod_container_port_name]
+        regex: calico-typha-monitoring;metrics
         action: keep
       - target_label: __address__
         replacement: kube-apiserver:443
+      - source_labels: [__meta_kubernetes_endpoint_node_name]
+        target_label: node
       - source_labels: [__meta_kubernetes_pod_name]
-        regex: (.+)
+        target_label: pod
+      - source_labels: [__meta_kubernetes_pod_name, __meta_kubernetes_pod_container_port_number]
+        regex: (.+);(.+)
         target_label: __metrics_path__
-        replacement: /api/v1/namespaces/kube-system/pods/${1}:9093/proxy/metrics
+        replacement: /api/v1/namespaces/kube-system/pods/${1}:${2}/proxy/metrics
+      metric_relabel_configs:
+      - source_labels: [ __name__ ]
+        regex: typha_.+
+        action: keep
 
   dashboard_operators: |
     calico-felix-dashboard.json: |-


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

- Use server side filtering for the endpoint discovery based on the
  namespace
- Only scrape the port named "metrics", use the port_number label instead
  of hard coding the port number
- Keep the node and pod labels. Previously, without those labels the
  series overwrote each other and only one series was persisted in
  Prometheus.
- Only keep the felix and typha metrics. Under some circumstances,
  these scrape targets somehow exposed api server metrics which caused
  confusion.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Improve the calico (felix and typha) scrape configuration
```
