### PR TITLE
Update calico typha cpva to not autoscale at the same step size for calico typha cpva and calico node cpva.

### DIFF
--- a/charts/internal/calico/templates/typha-cpva/configmap-typha-vertical-autoscaling.yaml
+++ b/charts/internal/calico/templates/typha-cpva/configmap-typha-vertical-autoscaling.yaml
@@ -11,29 +11,29 @@ data:
       "calico-typha": {
         "requests": {
           "cpu": {
-            "base": "120m",
-            "step": "80m",
-            "nodesPerStep": 10,
+            "base": "180m",
+            "step": "140m",
+            "nodesPerStep": 17,
             "max": "1000m"
           },
           "memory": {
-            "base": "100Mi",
-            "step": "40Mi",
-            "nodesPerStep": 10,
+            "base": "180Mi",
+            "step": "70Mi",
+            "nodesPerStep": 17,
             "max": "2000Mi"
           }
         },
         "limits": {
           "cpu": {
-            "base": "400m",
-            "step": "100m",
-            "nodesPerStep": 10,
+            "base": "500m",
+            "step": "170m",
+            "nodesPerStep": 17,
             "max": "1000m"
           },
           "memory": {
-            "base": "400Mi",
-            "step": "50Mi",
-            "nodesPerStep": 10,
+            "base": "600Mi",
+            "step": "85Mi",
+            "nodesPerStep": 17,
             "max": "2000Mi"
           }
         }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Update calico typha cpva to not autoscale at the same step size for calico typha cpva and calico node cpva.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update calico typha cpva to not autoscale at the same step size for calico typha cpva and calico node cpva.
```
