### PR TITLE
Removed support for outdated kubernetes releases.

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -4,31 +4,11 @@ images:
   repository: docker.io/calico/node
   tag: v3.22.0
   targetVersion: ">= 1.17"
-- name: calico-node
-  sourceRepository: github.com/projectcalico/calico
-  repository: docker.io/calico/node
-  tag: v3.19.1
-  targetVersion: ">= 1.16, < 1.17"
-- name: calico-node
-  sourceRepository: github.com/projectcalico/calico
-  repository: quay.io/calico/node
-  tag: v3.13.5
-  targetVersion: "< 1.16"
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
   repository: docker.io/calico/cni
   tag: v3.22.0
   targetVersion: ">= 1.17"
-- name: calico-cni
-  sourceRepository: github.com/projectcalico/cni-plugin
-  repository: docker.io/calico/cni
-  tag: v3.19.1
-  targetVersion: ">= 1.16, < 1.17"
-- name: calico-cni
-  sourceRepository: github.com/projectcalico/cni-plugin
-  repository: quay.io/calico/cni
-  tag: v3.13.5
-  targetVersion: "< 1.16"
 - name: calico-typha
   sourceRepository: github.com/projectcalico/typha
   repository: docker.io/calico/typha
@@ -39,56 +19,16 @@ images:
     value:
       policy: skip
       comment: payload are two statically linked ELF-binaries and some configuration/license files - not suitable for binary-id-scanning
-- name: calico-typha
-  sourceRepository: github.com/projectcalico/typha
-  repository: docker.io/calico/typha
-  tag: v3.19.1
-  targetVersion: ">= 1.16, < 1.17"
-  labels:
-  - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
-    value:
-      policy: skip
-      comment: payload are two statically linked ELF-binaries and some configuration/license files - not suitable for binary-id-scanning
-- name: calico-typha
-  sourceRepository: github.com/projectcalico/typha
-  repository: quay.io/calico/typha
-  tag: v3.13.5
-  targetVersion: "< 1.16"
-  labels:
-  - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
-    value:
-      policy: skip
-      comment: payload are two statically linked ELF-binaries and some configuration/license files - not suitable for binary-id-scanning
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers
   repository: docker.io/calico/kube-controllers
   tag: v3.22.0
   targetVersion: ">= 1.17"
-- name: calico-kube-controllers
-  sourceRepository: github.com/projectcalico/kube-controllers
-  repository: docker.io/calico/kube-controllers
-  tag: v3.19.1
-  targetVersion: ">= 1.16, < 1.17"
-- name: calico-kube-controllers
-  sourceRepository: github.com/projectcalico/kube-controllers
-  repository: quay.io/calico/kube-controllers
-  tag: v3.13.5
-  targetVersion: "< 1.16"
 - name: calico-podtodaemon-flex
   sourceRepository: github.com/projectcalico/pod2daemon
   repository: docker.io/calico/pod2daemon-flexvol
   tag: v3.22.0
   targetVersion: ">= 1.17"
-- name: calico-podtodaemon-flex
-  sourceRepository: github.com/projectcalico/pod2daemon
-  repository: docker.io/calico/pod2daemon-flexvol
-  tag: v3.19.1
-  targetVersion: ">= 1.16, < 1.17"
-- name: calico-podtodaemon-flex
-  sourceRepository: github.com/projectcalico/pod2daemon
-  repository: quay.io/calico/pod2daemon-flexvol
-  tag: v3.13.5
-  targetVersion: "< 1.16"
 - name: calico-cpa
   sourceRepository: github.com/kubernetes-sigs/cluster-proportional-autoscaler
   repository: k8s.gcr.io/cpa/cluster-proportional-autoscaler

--- a/charts/internal/calico/templates/custom-resource-definition/crd-bgpconfigurations.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-bgpconfigurations.yaml
@@ -1,20 +1,3 @@
-{{- if semverCompare "< 1.16" .Capabilities.KubeVersion.GitVersion }}
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: bgpconfigurations.crd.projectcalico.org
-  labels:
-    gardener.cloud/role: system-component
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: BGPConfiguration
-    plural: bgpconfigurations
-    singular: bgpconfiguration
-{{- else }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -159,4 +142,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/charts/internal/calico/templates/custom-resource-definition/crd-bgppeers.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-bgppeers.yaml
@@ -1,20 +1,3 @@
-{{- if semverCompare "< 1.16" .Capabilities.KubeVersion.GitVersion }}
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: bgppeers.crd.projectcalico.org
-  labels:
-    gardener.cloud/role: system-component
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: BGPPeer
-    plural: bgppeers
-    singular: bgppeer
-{{- else }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -129,4 +112,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/charts/internal/calico/templates/custom-resource-definition/crd-blockaffinities.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-blockaffinities.yaml
@@ -1,20 +1,3 @@
-{{- if semverCompare "< 1.16" .Capabilities.KubeVersion.GitVersion }}
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: blockaffinities.crd.projectcalico.org
-  labels:
-    gardener.cloud/role: system-component
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: BlockAffinity
-    plural: blockaffinities
-    singular: blockaffinity
-{{- else }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -77,4 +60,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/charts/internal/calico/templates/custom-resource-definition/crd-caliconodestatuses.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-caliconodestatuses.yaml
@@ -1,4 +1,3 @@
-{{- if semverCompare ">= 1.17" .Capabilities.KubeVersion.GitVersion }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -260,4 +259,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/charts/internal/calico/templates/custom-resource-definition/crd-clusterinformations.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-clusterinformations.yaml
@@ -1,20 +1,3 @@
-{{- if semverCompare "< 1.16" .Capabilities.KubeVersion.GitVersion }}
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: clusterinformations.crd.projectcalico.org
-  labels:
-    gardener.cloud/role: system-component
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: ClusterInformation
-    plural: clusterinformations
-    singular: clusterinformation
-{{- else }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -80,4 +63,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/charts/internal/calico/templates/custom-resource-definition/crd-felixconfigurations.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-felixconfigurations.yaml
@@ -1,20 +1,3 @@
-{{- if semverCompare "< 1.16" .Capabilities.KubeVersion.GitVersion }}
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: felixconfigurations.crd.projectcalico.org
-  labels:
-    gardener.cloud/role: system-component
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: FelixConfiguration
-    plural: felixconfigurations
-    singular: felixconfiguration
-{{- else }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -589,4 +572,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/charts/internal/calico/templates/custom-resource-definition/crd-globalnetworkpolicies.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-globalnetworkpolicies.yaml
@@ -1,20 +1,3 @@
-{{- if semverCompare "< 1.16" .Capabilities.KubeVersion.GitVersion }}
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: globalnetworkpolicies.crd.projectcalico.org
-  labels:
-    gardener.cloud/role: system-component
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: GlobalNetworkPolicy
-    plural: globalnetworkpolicies
-    singular: globalnetworkpolicy
-{{- else }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -871,4 +854,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/charts/internal/calico/templates/custom-resource-definition/crd-globalnetworksets.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-globalnetworksets.yaml
@@ -1,20 +1,3 @@
-{{- if semverCompare "< 1.16" .Capabilities.KubeVersion.GitVersion }}
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: globalnetworksets.crd.projectcalico.org
-  labels:
-    gardener.cloud/role: system-component
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: GlobalNetworkSet
-    plural: globalnetworksets
-    singular: globalnetworkset
-{{- else }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -69,4 +52,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/charts/internal/calico/templates/custom-resource-definition/crd-hostendpoints.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-hostendpoints.yaml
@@ -1,20 +1,3 @@
-{{- if semverCompare "< 1.16" .Capabilities.KubeVersion.GitVersion }}
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: hostendpoints.crd.projectcalico.org
-  labels:
-    gardener.cloud/role: system-component
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: HostEndpoint
-    plural: hostendpoints
-    singular: hostendpoint
-{{- else }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -124,4 +107,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/charts/internal/calico/templates/custom-resource-definition/crd-ipamblocks.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-ipamblocks.yaml
@@ -1,20 +1,3 @@
-{{- if semverCompare "< 1.16" .Capabilities.KubeVersion.GitVersion }}
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: ipamblocks.crd.projectcalico.org
-  labels:
-    gardener.cloud/role: system-component
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: IPAMBlock
-    plural: ipamblocks
-    singular: ipamblock
-{{- else }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -97,4 +80,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/charts/internal/calico/templates/custom-resource-definition/crd-ipamconfigs.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-ipamconfigs.yaml
@@ -1,20 +1,3 @@
-{{- if semverCompare "< 1.16" .Capabilities.KubeVersion.GitVersion }}
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: ipamconfigs.crd.projectcalico.org
-  labels:
-    gardener.cloud/role: system-component
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: IPAMConfig
-    plural: ipamconfigs
-    singular: ipamconfig
-{{- else }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -72,4 +55,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/charts/internal/calico/templates/custom-resource-definition/crd-ipamhandles.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-ipamhandles.yaml
@@ -1,20 +1,3 @@
-{{- if semverCompare "< 1.16" .Capabilities.KubeVersion.GitVersion }}
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: ipamhandles.crd.projectcalico.org
-  labels:
-    gardener.cloud/role: system-component
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: IPAMHandle
-    plural: ipamhandles
-    singular: ipamhandle
-{{- else }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -72,4 +55,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/charts/internal/calico/templates/custom-resource-definition/crd-ippools.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-ippools.yaml
@@ -1,20 +1,3 @@
-{{- if semverCompare "< 1.16" .Capabilities.KubeVersion.GitVersion }}
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: ippools.crd.projectcalico.org
-  labels:
-    gardener.cloud/role: system-component
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: IPPool
-    plural: ippools
-    singular: ippool
-{{- else }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -125,4 +108,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/charts/internal/calico/templates/custom-resource-definition/crd-ipreservations.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-ipreservations.yaml
@@ -1,4 +1,3 @@
-{{- if semverCompare ">= 1.17" .Capabilities.KubeVersion.GitVersion }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -51,4 +50,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/charts/internal/calico/templates/custom-resource-definition/crd-kubecontrollersconfiguration.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-kubecontrollersconfiguration.yaml
@@ -1,4 +1,3 @@
-{{- if semverCompare ">= 1.16" .Capabilities.KubeVersion.GitVersion }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -243,4 +242,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/charts/internal/calico/templates/custom-resource-definition/crd-networkpolicies.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-networkpolicies.yaml
@@ -1,20 +1,3 @@
-{{- if semverCompare "< 1.16" .Capabilities.KubeVersion.GitVersion }}
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: networkpolicies.crd.projectcalico.org
-  labels:
-    gardener.cloud/role: system-component
-spec:
-  scope: Namespaced
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: NetworkPolicy
-    plural: networkpolicies
-    singular: networkpolicy
-{{- else }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -852,4 +835,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/charts/internal/calico/templates/custom-resource-definition/crd-networksets.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-networksets.yaml
@@ -1,20 +1,3 @@
-{{- if semverCompare "< 1.16" .Capabilities.KubeVersion.GitVersion }}
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: networksets.crd.projectcalico.org
-  labels:
-    gardener.cloud/role: system-component
-spec:
-  scope: Namespaced
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: NetworkSet
-    plural: networksets
-    singular: networkset
-{{- else }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -67,4 +50,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/charts/internal/calico/templates/kube-controller/clusterrole-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/clusterrole-calico-kube-controllers.yaml
@@ -40,7 +40,6 @@ rules:
       - update
       - delete
       - watch
-{{- if semverCompare ">= 1.16" .Capabilities.KubeVersion.GitVersion  }}
   # kube-controllers manages hostendpoints.
   - apiGroups: ["crd.projectcalico.org"]
     resources:
@@ -51,7 +50,6 @@ rules:
       - create
       - update
       - delete
-{{- end }}
   # Needs access to update clusterinformations.
   - apiGroups: ["crd.projectcalico.org"]
     resources:
@@ -60,7 +58,6 @@ rules:
       - get
       - create
       - update
-{{- if semverCompare ">= 1.16" .Capabilities.KubeVersion.GitVersion  }}
   # KubeControllersConfiguration is where it gets its config
   - apiGroups: ["crd.projectcalico.org"]
     resources:
@@ -74,5 +71,4 @@ rules:
       - update
       # watch for changes
       - watch
-{{- end }}
 {{- end }}

--- a/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
@@ -10,10 +10,6 @@ metadata:
   labels:
     k8s-app: calico-kube-controllers
     gardener.cloud/role: system-component
-  {{- if semverCompare "< 1.16" .Capabilities.KubeVersion.GitVersion }}
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ''
-  {{- end }}
 spec:
   # The controllers can only have a single active instance.
   replicas: 1

--- a/charts/internal/calico/templates/kube-controller/pod-disruption-budget.yaml
+++ b/charts/internal/calico/templates/kube-controller/pod-disruption-budget.yaml
@@ -1,4 +1,3 @@
-{{- if semverCompare ">= 1.16" .Capabilities.KubeVersion.GitVersion }}
 {{- if .Values.config.kubeControllers.enabled }}
 ---
 apiVersion: policy/v1beta1
@@ -13,5 +12,4 @@ spec:
   selector:
     matchLabels:
       k8s-app: calico-kube-controllers
-{{- end }}
 {{- end }}

--- a/charts/internal/calico/templates/node/configmap-calico-config.yaml
+++ b/charts/internal/calico/templates/node/configmap-calico-config.yaml
@@ -30,9 +30,7 @@ data:
         {
           "type": "calico",
           "log_level": "error",
-        {{- if semverCompare ">= 1.16" .Capabilities.KubeVersion.GitVersion }}
           "log_file_path": "/var/log/calico/cni/cni.log",
-        {{- end }}
           "datastore_type": "kubernetes",
           "nodename": "__KUBERNETES_NODE_NAME__",
           "mtu": __CNI_MTU__,

--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -30,13 +30,6 @@ spec:
         k8s-app: calico-node
         gardener.cloud/role: system-component
       annotations:
-        {{- if semverCompare "< 1.16" .Capabilities.KubeVersion.GitVersion }}
-        # This, along with the CriticalAddonsOnly toleration below,
-        # marks the pod as a critical add-on, ensuring it gets
-        # priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        {{- end }}
         checksum/configmap-calico: {{ include (print $.Template.BasePath "/node/configmap-calico-config.yaml") . | sha256sum }}
     spec:
       nodeSelector:
@@ -61,18 +54,12 @@ spec:
       # and CNI network config file on each node.
       - name: install-cni
         image: {{ index .Values.images "calico-cni" }}
-        {{- if semverCompare "< 1.16" .Capabilities.KubeVersion.GitVersion }}
-        command: ["/install-cni.sh"]
-        {{- else}}
         command: ["/opt/cni/bin/install"]
-        {{- end }}
-        {{- if semverCompare ">= 1.16" .Capabilities.KubeVersion.GitVersion  }}
         envFrom:
         - configMapRef:
             # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
             name: kubernetes-services-endpoint
             optional: true
-        {{- end }}
         env:
           # Name of the CNI config file to create.
           - name: CNI_CONF_NAME
@@ -121,13 +108,11 @@ spec:
         # host.
         - name: calico-node
           image: {{ index .Values.images "calico-node" }}
-          {{- if semverCompare ">= 1.16" .Capabilities.KubeVersion.GitVersion  }}
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
               name: kubernetes-services-endpoint
               optional: true
-          {{- end }}
           ports:
             {{- if .Values.config.monitoring.enabled }}
           - containerPort: {{  .Values.config.monitoring.felixMetricsPort }}
@@ -172,27 +157,22 @@ spec:
             - name: CLUSTER_TYPE
               value: "k8s,bgp"
             # Auto-detect the BGP IP address.
-            {{- if semverCompare ">= 1.16" .Capabilities.KubeVersion.GitVersion  }}
             {{- if .Values.config.ipv4.autoDetectionMethod }}
             # On metal the ip is bound to the lo interface (routing to the host).
             - name: IP_AUTODETECTION_METHOD
               value: "{{ .Values.config.ipv4.autoDetectionMethod }}"
             {{- end }}
-            {{- end }}
             - name: IP
               value: "autodetect"
-            {{- if semverCompare ">= 1.16" .Capabilities.KubeVersion.GitVersion  }}
             # Enable or Disable VXLAN on the default IP pool.
             - name: CALICO_IPV4POOL_VXLAN
               value: "Never"
-            {{- end }}
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
                   key: veth_mtu
-            {{- if semverCompare ">= 1.16" .Capabilities.KubeVersion.GitVersion  }}
             # Set MTU for the VXLAN tunnel device.
             - name: FELIX_VXLANMTU
               valueFrom:
@@ -205,7 +185,6 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: veth_mtu
-            {{- end }}
             # The default IPv4 pool to create on startup if none exists. Pod IPs will be
             # chosen from this range. Changing this value after installation will have
             # no effect. This should fall within `--cluster-cidr`.
@@ -294,7 +273,6 @@ spec:
               readOnly: false
             - name: policysync
               mountPath: /var/run/nodeagent
-            {{- if semverCompare ">= 1.16" .Capabilities.KubeVersion.GitVersion  }}
             # For eBPF mode, we need to be able to mount the BPF filesystem at /sys/fs/bpf so we mount in the
             # parent directory.
             - name: sysfs
@@ -302,7 +280,6 @@ spec:
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
-              {{- end }}
       volumes:
         # Used by calico-node.
         - name: lib-modules
@@ -318,12 +295,10 @@ spec:
           hostPath:
             path: /run/xtables.lock
             type: FileOrCreate
-        {{- if semverCompare ">= 1.16" .Capabilities.KubeVersion.GitVersion  }}
         - name: sysfs
           hostPath:
             path: /sys/fs/
             type: DirectoryOrCreate
-        {{- end }}
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:


### PR DESCRIPTION
Now, kubernetes 1.17 and above is required as the minimum.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
Removed support for outdated kubernetes releases.
Now, kubernetes 1.17 and above is required as the minimum.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Kubernetes releases older than 1.17 are no longer supported by the gardener calico extension.
```
