### PR TITLE
Allow typha deployment updates even on single node clusters.

### DIFF
--- a/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
@@ -26,7 +26,9 @@ spec:
     # Ensure that typha always stays available
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 0
+      # We would want maxUnavailable=0, but for one node cluster this would block updates
+      # as the port would already be occupied due to usage of host network
+      maxUnavailable: 1
       maxSurge: 25%
   selector:
     matchLabels:


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Allow typha deployment updates even on single node clusters.

As calico-typha is crucial to calico-node's operation, we want it to be available all the time.
However, setting maxUnavailable=0 in the rollingUpdate strategy of the deployment will block
updates on single node clusters. This is due to the fact that calico-typha runs in the host
network and uses a static port. Hence, a new container cannot run on the single node until the
old instance is stopped.
Therefore, we bite the bullet and allow unavailability of one instance.
**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow calico-typha update in single node clusters
```
