### PR TITLE
Removed cpu limits for calico-node, calico-typha, and the calico autoscalers and increased the memory limits.

### DIFF
--- a/charts/internal/calico/templates/node-cpva/configmap-node-vertical-autoscaling.yaml
+++ b/charts/internal/calico/templates/node-cpva/configmap-node-vertical-autoscaling.yaml
@@ -17,17 +17,9 @@ data:
           }
         },
         "limits": {
-          "cpu": {
-            "base": "320m",
-            "step": "80m",
-            "nodesPerStep": 10,
-            "max": "800m"
-          },
           "memory": {
-            "base": "650Mi",
-            "step": "50Mi",
-            "nodesPerStep": 10,
-            "max": "1400Mi"
+            "base": "2800Mi",
+            "max": "2800Mi"
           }
         }
       }

--- a/charts/internal/calico/templates/node-cpva/deployment-calico-node-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/node-cpva/deployment-calico-node-vertical-autoscaler.yaml
@@ -47,7 +47,6 @@ spec:
               cpu: 10m
               memory: 50Mi
             limits:
-              cpu: 10m
               memory: 200Mi
           volumeMounts:
             - name: config

--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -249,8 +249,7 @@ spec:
               cpu: 250m
               memory: 100Mi
             limits:
-              cpu: 800m
-              memory: 1400Mi
+              memory: 2800Mi
           livenessProbe:
             exec:
               command:

--- a/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
@@ -50,7 +50,6 @@ spec:
               cpu: 10m
               memory: 50Mi
             limits:
-              cpu: 10m
               memory: 200Mi
       serviceAccountName: typha-cpha
 {{- end }}

--- a/charts/internal/calico/templates/typha-cpva/configmap-typha-vertical-autoscaling.yaml
+++ b/charts/internal/calico/templates/typha-cpva/configmap-typha-vertical-autoscaling.yaml
@@ -24,17 +24,9 @@ data:
           }
         },
         "limits": {
-          "cpu": {
-            "base": "500m",
-            "step": "170m",
-            "nodesPerStep": 17,
-            "max": "1000m"
-          },
           "memory": {
-            "base": "600Mi",
-            "step": "85Mi",
-            "nodesPerStep": 17,
-            "max": "2000Mi"
+            "base": "4000Mi",
+            "max": "4000Mi"
           }
         }
       }

--- a/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
@@ -49,7 +49,6 @@ spec:
               cpu: 10m
               memory: 50Mi
             limits:
-              cpu: 10m
               memory: 200Mi
           volumeMounts:
             - name: config

--- a/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
@@ -125,8 +125,7 @@ spec:
             cpu: 200m
             memory: 100Mi
           limits:
-            cpu: 1000m
-            memory: 2000Mi
+            memory: 4000Mi
         securityContext:
           runAsNonRoot: true
           allowPrivilegeEscalation: false


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind technical-debt

**What this PR does / why we need it**:
Removed cpu limits for calico-node, calico-typha, and the calico autoscalers (calico-node-vertical-autoscaler,
calico-typha-horizontal-autoscaler, calico-typha-vertical-autoscaler) and increased the memory limits.

The memory limits of calico-node and calico-typha will no longer be autoscaler, but they are static at a fairly
high level. CPU limits are no longer enforced to prevent unnecessary throttling.
The downside of the current approach is that it will only be applied to new clusters. Existing clusters will stay
with the existing limits, which can be removed, though.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Calico components will no longer have cpu limits in new clusters, calico memory limits will no longer be autoscaled, but they set to a high static value.
```
