### PR TITLE
update calico cpu limits to 1000 for calico node and calico typha

### DIFF
--- a/charts/internal/calico/templates/node-cpva/configmap-node-vertical-autoscaling.yaml
+++ b/charts/internal/calico/templates/node-cpva/configmap-node-vertical-autoscaling.yaml
@@ -17,6 +17,10 @@ data:
           }
         },
         "limits": {
+          "cpu": {
+            "base": "1000",
+            "max": "1000"
+          },
           "memory": {
             "base": "2800Mi",
             "max": "2800Mi"

--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -224,6 +224,7 @@ spec:
               cpu: 250m
               memory: 100Mi
             limits:
+              cpu: "1000"
               memory: 2800Mi
           lifecycle:
             preStop:

--- a/charts/internal/calico/templates/typha-cpva/configmap-typha-vertical-autoscaling.yaml
+++ b/charts/internal/calico/templates/typha-cpva/configmap-typha-vertical-autoscaling.yaml
@@ -24,6 +24,10 @@ data:
           }
         },
         "limits": {
+          "cpu": {
+            "base": "1000",
+            "max": "1000"
+          },
           "memory": {
             "base": "4000Mi",
             "max": "4000Mi"

--- a/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
@@ -125,6 +125,7 @@ spec:
             cpu: 200m
             memory: 100Mi
           limits:
+            cpu: "1000"
             memory: 4000Mi
         livenessProbe:
           httpGet:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancemnt

**What this PR does / why we need it**:
Update calico cpu limits to 1000 cores for calico node and calico typha.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update calico cpu limits to 1000 cores for calico node and calico typha.
```
