### PR TITLE
Adapt calico-kube-controllers to remove cpu limit and increase readiness probe timeout.

### DIFF
--- a/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
@@ -65,7 +65,6 @@ spec:
               cpu: 10m
               memory: 50Mi
             limits:
-              cpu: 50m
               memory: 300Mi
           livenessProbe:
             exec:
@@ -82,6 +81,7 @@ spec:
                 - /usr/bin/check-status
                 - -r
             periodSeconds: 10
+            timeoutSeconds: 10
           securityContext:
             capabilities:
               drop:


### PR DESCRIPTION




**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Adapt calico-kube-controllers to remove cpu limit and increase readiness probe timeout.

In bigger clusters with a lot of activity the calico-kube-controllers pod may run into
throttling issues due to the cpu limit. Furthermore, the readiness probe may timeout.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Adapt calico-kube-controllers to remove cpu limit and increase readiness probe timeout.
```
