### PR TITLE
Adapted memory limits to real world experience.

### DIFF
--- a/charts/internal/calico/templates/node-cpva/deployment-calico-node-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/node-cpva/deployment-calico-node-vertical-autoscaler.yaml
@@ -47,7 +47,7 @@ spec:
               cpu: 10m
               memory: 50Mi
             limits:
-              memory: 200Mi
+              memory: 130Mi
           volumeMounts:
             - name: config
               mountPath: /etc/config

--- a/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
@@ -50,6 +50,6 @@ spec:
               cpu: 10m
               memory: 50Mi
             limits:
-              memory: 200Mi
+              memory: 100Mi
       serviceAccountName: typha-cpha
 {{- end }}

--- a/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
@@ -49,7 +49,7 @@ spec:
               cpu: 10m
               memory: 50Mi
             limits:
-              memory: 200Mi
+              memory: 130Mi
           volumeMounts:
             - name: config
               mountPath: /etc/config


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Adapted memory limits to real world experience.

The memory limits of the calico autoscalers were changed to about four times
the maximum we see in real world scenarios. Therefore, we have some buffer
in case something goes wrong.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Memory limit of calico autoscalers reduced to fit to real world scenarios.
```
