### PR TITLE
Allow projected volumes for calico-node, calico-typha and calico-kube-controllers

### DIFF
--- a/charts/internal/calico/templates/kube-controller/psp-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/psp-calico-kube-controllers.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   volumes:
     - secret
+    - projected
   hostIPC: false
   hostNetwork: false
   hostPID: false

--- a/charts/internal/calico/templates/node-cpva/psp-gardener-node-cpva.yaml
+++ b/charts/internal/calico/templates/node-cpva/psp-gardener-node-cpva.yaml
@@ -2,10 +2,11 @@
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
 metadata:
-  name: gardener.cloud.calico-node-cpva
+  name: gardener.kube-system.calico-node-cpva
 spec:
   volumes:
-  - secret
+  - configMap
+  - projected
   runAsUser:
     rule: MustRunAsNonRoot
   seLinux:

--- a/charts/internal/calico/templates/node/psp-calico.yaml
+++ b/charts/internal/calico/templates/node/psp-calico.yaml
@@ -8,6 +8,7 @@ spec:
   volumes:
   - hostPath
   - secret
+  - projected
   hostNetwork: true
   {{- if .Values.config.monitoring.enabled }}
   hostPorts:

--- a/charts/internal/calico/templates/typha-cpha/psp-gardener-typha-cpa.yaml
+++ b/charts/internal/calico/templates/typha-cpha/psp-gardener-typha-cpa.yaml
@@ -6,7 +6,7 @@ metadata:
   name: gardener.kube-system.typha-cpa
 spec:
   volumes:
-  - secret
+  - projected
   runAsUser:
     rule: MustRunAsNonRoot
   seLinux:

--- a/charts/internal/calico/templates/typha-cpva/psp-gardener-typha-cpva.yaml
+++ b/charts/internal/calico/templates/typha-cpva/psp-gardener-typha-cpva.yaml
@@ -3,10 +3,11 @@
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
 metadata:
-  name: gardener.cloud.typha-cpva
+  name: gardener.kube-system.typha-cpva
 spec:
   volumes:
-  - secret
+  - configMap
+  - projected
   runAsUser:
     rule: MustRunAsNonRoot
   seLinux:

--- a/charts/internal/calico/templates/typha/psp-gardener-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/psp-gardener-calico-typha.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   volumes:
   - secret
+  - projected
   hostNetwork: true
   hostPorts:
   - min: 5473


### PR DESCRIPTION
/area networking
/kind bug
/kind regression

After https://github.com/gardener/gardener-extension-networking-calico/pull/137 the calico-node, calico-typha and calico-kube-controllers PSPs have to be adapted to allow projected volumes. 
Current for these components the Pod creations fail with:
```
  Warning  FailedCreate  13s (x8 over 95s)  daemonset-controller  Error creating: pods "calico-node-" is forbidden: unable to validate against any pod security policy: [spec.volumes[10]: Invalid value: "projected": projected volumes are not allowed to be used spec.securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used spec.volumes[0]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[1]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[2]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[3]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[4]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[5]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[6]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[7]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[8]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[9]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.initContainers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed spec.initContainers[1].securityContext.privileged: Invalid value: true: Privileged containers are not allowed spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed spec.containers[0].hostPort: Invalid value: 9091: Host port 9091 is not allowed to be used. Allowed ports: []]
```

```
  Warning  FailedCreate  111s (x11 over 4m35s)  replicaset-controller  Error creating: pods "calico-typha-deploy-65b894c58d-" is forbidden: unable to validate against any pod security policy: [spec.volumes[0]: Invalid value: "projected": projected volumes are not allowed to be used spec.securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used spec.containers[0].hostPort: Invalid value: 5473: Host port 5473 is not allowed to be used. Allowed ports: [] spec.containers[0].hostPort: Invalid value: 9093: Host port 9093 is not allowed to be used. Allowed ports: []]
```

```
  Warning  FailedCreate  53s (x8 over 3m37s)    replicaset-controller  Error creating: pods "calico-kube-controllers-55b4b499c4-" is forbidden: unable to validate against any pod security policy: [spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed spec.containers[0].securityContext.allowPrivilegeEscalation: Invalid value: true: Allowing privilege escalation for containers is not allowed spec.volumes[0]: Invalid value: "projected": projected volumes are not allowed to be used]
```

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/510

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue causing Pod creation to fail for calico-node, calico-typha and calico-kube-controllers components when privileged containers are not allowed is now fixed.
```
