### PR TITLE
[release-v1.24] Automated cherry pick of #181: Allow projected volumes for calico-node, calico-typha and calico-kube-controllers

### DIFF
--- a/charts/internal/calico/templates/kube-controller/psp-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/psp-calico-kube-controllers.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   volumes:
     - secret
+    - projected
   hostIPC: false
   hostNetwork: false
   hostPID: false

--- a/charts/internal/calico/templates/node-cpva/psp-gardener-node-cpva.yaml
+++ b/charts/internal/calico/templates/node-cpva/psp-gardener-node-cpva.yaml
@@ -2,10 +2,11 @@
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
 metadata:
-  name: gardener.cloud.calico-node-cpva
+  name: gardener.kube-system.calico-node-cpva
 spec:
   volumes:
-  - secret
+  - configMap
+  - projected
   runAsUser:
     rule: MustRunAsNonRoot
   seLinux:

--- a/charts/internal/calico/templates/node/psp-calico.yaml
+++ b/charts/internal/calico/templates/node/psp-calico.yaml
@@ -8,6 +8,7 @@ spec:
   volumes:
   - hostPath
   - secret
+  - projected
   hostNetwork: true
   {{- if .Values.config.monitoring.enabled }}
   hostPorts:

--- a/charts/internal/calico/templates/typha-cpha/psp-gardener-typha-cpa.yaml
+++ b/charts/internal/calico/templates/typha-cpha/psp-gardener-typha-cpa.yaml
@@ -6,7 +6,7 @@ metadata:
   name: gardener.kube-system.typha-cpa
 spec:
   volumes:
-  - secret
+  - projected
   runAsUser:
     rule: MustRunAsNonRoot
   seLinux:

--- a/charts/internal/calico/templates/typha-cpva/psp-gardener-typha-cpva.yaml
+++ b/charts/internal/calico/templates/typha-cpva/psp-gardener-typha-cpva.yaml
@@ -3,10 +3,11 @@
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
 metadata:
-  name: gardener.cloud.typha-cpva
+  name: gardener.kube-system.typha-cpva
 spec:
   volumes:
-  - secret
+  - configMap
+  - projected
   runAsUser:
     rule: MustRunAsNonRoot
   seLinux:

--- a/charts/internal/calico/templates/typha/psp-gardener-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/psp-gardener-calico-typha.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   volumes:
   - secret
+  - projected
   hostNetwork: true
   hostPorts:
   - min: 5473


### PR DESCRIPTION
/area/networking
/kind/bug
/kind/regression

Cherry pick of #181 on release-v1.24.

#181: Allow projected volumes for calico-node, calico-typha and calico-kube-controllers

**Release Notes:**
```bugfix user
An issue causing Pod creation to fail for calico-node, calico-typha and calico-kube-controllers components when privileged containers are not allowed is now fixed.
```