### PR TITLE
Do not run calico-kube-controllers in privileged mode

### DIFF
--- a/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
@@ -48,9 +48,6 @@ spec:
       priorityClassName: system-cluster-critical
       # Make sure to not use the coredns for DNS resolution.
       dnsPolicy: Default
-      hostIPC: false
-      hostNetwork: false
-      hostPID: false
       containers:
         - name: calico-kube-controllers
           image: {{ index .Values.images "calico-kube-controllers" }}
@@ -82,12 +79,4 @@ spec:
                 - -r
             periodSeconds: 10
             timeoutSeconds: 10
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
-            allowPrivilegeEscalation: true
-            # Health checks are written on a file which is
-            # writable only to root
-            privileged: true
 {{- end }}

--- a/charts/internal/calico/templates/kube-controller/psp-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/psp-calico-kube-controllers.yaml
@@ -8,13 +8,10 @@ spec:
   volumes:
     - secret
     - projected
-  hostIPC: false
-  hostNetwork: false
-  hostPID: false
-  privileged: true
-  requiredDropCapabilities:
-    - ALL
+  privileged: false
   runAsUser:
+    # TODO(ialidzhikov): Switch to MustRunAsNonRoot when the arm64 image of the calico-kube-controllers
+    # does no longer run as root. Ref https://github.com/projectcalico/calico/pull/6346.
     rule: RunAsAny
   seLinux:
     rule: RunAsAny


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
As part of https://github.com/gardener-security/standard-compliance/issues/3 we need to make sure that we do not run containers in privileged mode but rather assign them the needed capabilities  (if needed).

The upstream calico chart does not run calico-kube-controllers in privileged mode - https://github.com/projectcalico/calico/blob/v3.23.2/calico/_includes/charts/calico/templates/calico-kube-controllers.yaml#L2-L123.
The privileged mode was introduced several years ago with https://github.com/gardener/gardener/pull/1120 as a fix for https://github.com/gardener/gardener/issues/1119. Since then the calico-kube-controllers image was adapted to specify a default user (with uid 999)  in its Dockerfile and no longer requires to run as root - ref https://github.com/projectcalico/kube-controllers/pull/565. Having this in mind it should be ok to run the calico-kube-controllers in non-privileged mode.
Right now the arm64 image does not specify a default user (https://github.com/projectcalico/calico/issues/5713). When https://github.com/projectcalico/calico/issues/5713 is fixed we can also adapt the PodSecurityPolicy to impose the `MustRunAsNonRoot` rule instead of the current `RunAsAny`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener-security/standard-compliance/issues/3

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The calico-kube-controllers/calico-kube-controllers container no longer runs in privileged mode.
```
