### PR TITLE
update calico to v3.23.3

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
   repository: docker.io/calico/node
-  tag: v3.23.2
+  tag: v3.23.3
   targetVersion: ">= 1.21"
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
@@ -12,7 +12,7 @@ images:
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
   repository: docker.io/calico/cni
-  tag: v3.23.2
+  tag: v3.23.3
   targetVersion: ">= 1.21"
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
@@ -22,7 +22,7 @@ images:
 - name: calico-typha
   sourceRepository: github.com/projectcalico/typha
   repository: docker.io/calico/typha
-  tag: v3.23.2
+  tag: v3.23.3
   targetVersion: ">= 1.21"
   labels:
   - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
@@ -42,7 +42,7 @@ images:
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers
   repository: docker.io/calico/kube-controllers
-  tag: v3.23.2
+  tag: v3.23.3
   targetVersion: ">= 1.21"
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers

--- a/charts/internal/calico/templates/custom-resource-definition/crd-felixconfigurations.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-felixconfigurations.yaml
@@ -900,7 +900,6 @@ spec:
                   are auto-detected.
                 type: string
               floatingIPs:
-                default: Disabled
                 description: FloatingIPs configures whether or not Felix will program
                   floating IP addresses.
                 enum:

--- a/charts/internal/calico/templates/node/clusterrole-calico-node.yaml
+++ b/charts/internal/calico/templates/node/clusterrole-calico-node.yaml
@@ -7,6 +7,16 @@ kind: ClusterRole
 metadata:
   name: calico-node
 rules:
+  {{- if semverCompare ">= 1.21-0" .Capabilities.KubeVersion.GitVersion }}
+  # Used for creating service account tokens to be used by the CNI plugin
+  - apiGroups: [""]
+    resources:
+      - serviceaccounts/token
+    resourceNames:
+      - calico-node
+    verbs:
+      - create
+  {{- end }}
   # The CNI plugin needs to get pods, nodes, and namespaces.
   - apiGroups: [""]
     resources:
@@ -69,16 +79,6 @@ rules:
       - pods/status
     verbs:
       - patch
-  {{- if semverCompare "> 1.20" .Capabilities.KubeVersion.GitVersion }}
-  # Used for creating service account tokens to be used by the CNI plugin
-  - apiGroups: [""]
-    resources:
-      - serviceaccounts/token
-    resourceNames:
-      - calico-node
-    verbs:
-      - create
-  {{- end }}
   # Calico monitors various CRDs for config.
   - apiGroups: ["crd.projectcalico.org"]
     resources:

--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -93,6 +93,32 @@ spec:
             name: cni-bin-dir
         securityContext:
           privileged: true
+      {{- if semverCompare ">= 1.21-0" .Capabilities.KubeVersion.GitVersion }}
+      # This init container mounts the necessary filesystems needed by the BPF data plane
+      # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
+      # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
+      - name: mount-bpffs
+        image: {{ index .Values.images "calico-node" }}
+        command: ["calico-node", "-init", "-best-effort"]
+        volumeMounts:
+          - mountPath: /sys/fs
+            name: sys-fs
+            # Bidirectional is required to ensure that the new mount we make at /sys/fs/bpf propagates to the host
+            # so that it outlives the init container.
+            mountPropagation: Bidirectional
+          - mountPath: /var/run/calico
+            name: var-run-calico
+            # Bidirectional is required to ensure that the new mount we make at /run/calico/cgroup propagates to the host
+            # so that it outlives the init container.
+            mountPropagation: Bidirectional
+          # Mount /proc/ from host which usually is an init program at /nodeproc. It's needed by mountns binary,
+          # executed by calico-node, to mount root cgroup2 fs at /run/calico/cgroup to attach CTLB programs correctly.
+          - mountPath: /nodeproc
+            name: nodeproc
+            readOnly: true
+        securityContext:
+          privileged: true
+      {{- end }}
       {{- if semverCompare "< 1.21" .Capabilities.KubeVersion.GitVersion }}
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
@@ -281,8 +307,13 @@ spec:
               mountPath: /var/run/nodeagent
             # For eBPF mode, we need to be able to mount the BPF filesystem at /sys/fs/bpf so we mount in the
             # parent directory.
+            {{- if semverCompare ">= 1.21-0" .Capabilities.KubeVersion.GitVersion }}
+            - name: bpffs
+              mountPath: /sys/fs/bpf
+            {{- else }}
             - name: sysfs
               mountPath: /sys/fs/
+            {{- end }}
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -301,10 +332,24 @@ spec:
           hostPath:
             path: /run/xtables.lock
             type: FileOrCreate
+        {{- if semverCompare ">= 1.21-0" .Capabilities.KubeVersion.GitVersion }}
+        - name: sys-fs
+        {{- else }}
         - name: sysfs
+        {{- end }}
           hostPath:
             path: /sys/fs/
             type: DirectoryOrCreate
+        {{- if semverCompare ">= 1.21-0" .Capabilities.KubeVersion.GitVersion }}
+        - name: bpffs
+          hostPath:
+            path: /sys/fs/bpf
+            type: Directory
+        # mount /proc at /nodeproc to be used by mount-bpffs initContainer to mount root cgroup2 fs.
+        - name: nodeproc
+          hostPath:
+            path: /proc
+        {{- end }}
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Update calico to v3.23.3.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update calico to v3.23.3.
```
