### PR TITLE
Don't deploy `PSP`s when `PodSecurityPolicy` plugin is disabled 

### DIFF
--- a/charts/internal/calico/templates/kube-controller/clusterrole-garden-psp-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/clusterrole-garden-psp-calico-kube-controllers.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.kubeControllers.enabled }}
+{{- if and (.Values.config.kubeControllers.enabled) (not .Values.pspDisabled) }}
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole

--- a/charts/internal/calico/templates/kube-controller/psp-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/psp-calico-kube-controllers.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.kubeControllers.enabled }}
+{{- if and (.Values.config.kubeControllers.enabled) (not .Values.pspDisabled) }}
 ---
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy

--- a/charts/internal/calico/templates/kube-controller/rolebinding-garden-psp-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/rolebinding-garden-psp-calico-kube-controllers.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.kubeControllers.enabled }}
+{{- if and (.Values.config.kubeControllers.enabled) (not .Values.pspDisabled) }}
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding

--- a/charts/internal/calico/templates/node-cpva/clusterrole-gardener-psp-node-cpva.yaml
+++ b/charts/internal/calico/templates/node-cpva/clusterrole-gardener-psp-node-cpva.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.pspDisabled }}
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
@@ -13,3 +14,4 @@ rules:
       - podsecuritypolicies
     verbs:
       - use
+{{- end }}

--- a/charts/internal/calico/templates/node-cpva/deployment-calico-node-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/node-cpva/deployment-calico-node-vertical-autoscaler.yaml
@@ -28,7 +28,11 @@ spec:
       {{- end }}
       priorityClassName: system-cluster-critical
       securityContext:
+        runAsNonRoot: true
         runAsUser: 65534
+        fsGroup: 1
+        supplementalGroups:
+        - 1
       # Make sure to not use the coredns for DNS resolution.
       dnsPolicy: Default
       containers:

--- a/charts/internal/calico/templates/node-cpva/psp-gardener-node-cpva.yaml
+++ b/charts/internal/calico/templates/node-cpva/psp-gardener-node-cpva.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.pspDisabled }}
 ---
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
@@ -21,3 +22,4 @@ spec:
     ranges:
     - min: 1
       max: 65534
+{{- end }}

--- a/charts/internal/calico/templates/node-cpva/rolebinding-gardener-psp-node-cpva.yaml
+++ b/charts/internal/calico/templates/node-cpva/rolebinding-gardener-psp-node-cpva.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.pspDisabled }}
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding
@@ -12,3 +13,4 @@ subjects:
   - kind: ServiceAccount
     name: calico-node-cpva
     namespace: kube-system
+{{- end }}

--- a/charts/internal/calico/templates/node/clusterrole-garden-psp-calico.yaml
+++ b/charts/internal/calico/templates/node/clusterrole-garden-psp-calico.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.pspDisabled }}
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
@@ -13,3 +14,4 @@ rules:
   - podsecuritypolicies
   verbs:
   - use
+{{- end }}

--- a/charts/internal/calico/templates/node/psp-calico.yaml
+++ b/charts/internal/calico/templates/node/psp-calico.yaml
@@ -37,4 +37,4 @@ spec:
   fsGroup:
     rule: RunAsAny
   readOnlyRootFilesystem: false
-{{- end}}
+{{- end }}

--- a/charts/internal/calico/templates/node/psp-calico.yaml
+++ b/charts/internal/calico/templates/node/psp-calico.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.pspDisabled }}
 ---
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
@@ -36,3 +37,4 @@ spec:
   fsGroup:
     rule: RunAsAny
   readOnlyRootFilesystem: false
+{{- end}}

--- a/charts/internal/calico/templates/node/rolebinding-garden-psp-calico.yaml
+++ b/charts/internal/calico/templates/node/rolebinding-garden-psp-calico.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.pspDisabled }}
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding
@@ -12,3 +13,4 @@ subjects:
 - kind: ServiceAccount
   name: calico-node
   namespace: kube-system
+{{- end }}

--- a/charts/internal/calico/templates/typha-cpha/clusterrole-gardener-psp-typha-cpha.yaml
+++ b/charts/internal/calico/templates/typha-cpha/clusterrole-gardener-psp-typha-cpha.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.typha.enabled }}
+{{- if and (.Values.config.typha.enabled) (not .Values.pspDisabled) }}
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole

--- a/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
@@ -35,6 +35,7 @@ spec:
         supplementalGroups: [ 65532 ]
         fsGroup: 65532
         runAsUser: 65532
+        runAsNonRoot: true
       containers:
         - image: {{ index .Values.images "calico-cpa" }}
           name: autoscaler

--- a/charts/internal/calico/templates/typha-cpha/psp-gardener-typha-cpa.yaml
+++ b/charts/internal/calico/templates/typha-cpha/psp-gardener-typha-cpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.typha.enabled }}
+{{- if and (.Values.config.typha.enabled) (not .Values.pspDisabled) }}
 ---
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy

--- a/charts/internal/calico/templates/typha-cpha/rolebinding-gardener-psp-typha-cpa.yaml
+++ b/charts/internal/calico/templates/typha-cpha/rolebinding-gardener-psp-typha-cpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.typha.enabled }}
+{{- if and (.Values.config.typha.enabled) (not .Values.pspDisabled) }}
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding

--- a/charts/internal/calico/templates/typha-cpva/clusterrole-gardener-psp-typha-cpva.yaml
+++ b/charts/internal/calico/templates/typha-cpva/clusterrole-gardener-psp-typha-cpva.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.typha.enabled }}
+{{- if and (.Values.config.typha.enabled) (not .Values.pspDisabled) }}
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole

--- a/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
@@ -33,6 +33,10 @@ spec:
       dnsPolicy: Default
       securityContext:
         runAsUser: 65534
+        runAsNonRoot: true
+        supplementalGroups:
+        - 1
+        fsGroup: 1
       containers:
         - image:  {{ index .Values.images "calico-cpva" }}
           name: autoscaler

--- a/charts/internal/calico/templates/typha-cpva/psp-gardener-typha-cpva.yaml
+++ b/charts/internal/calico/templates/typha-cpva/psp-gardener-typha-cpva.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.typha.enabled }}
+{{- if and (.Values.config.typha.enabled) (not .Values.pspDisabled) }}
 ---
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy

--- a/charts/internal/calico/templates/typha-cpva/rolebinding-gardener-psp-typha-cpva.yaml
+++ b/charts/internal/calico/templates/typha-cpva/rolebinding-gardener-psp-typha-cpva.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.typha.enabled }}
+{{- if and (.Values.config.typha.enabled) (not .Values.pspDisabled) }}
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding

--- a/charts/internal/calico/templates/typha/clusterrole-garden-psp-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/clusterrole-garden-psp-calico-typha.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.typha.enabled }}
+{{- if and (.Values.config.typha.enabled) (not .Values.pspDisabled) }}
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole

--- a/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
@@ -75,6 +75,8 @@ spec:
       securityContext:
         runAsUser: 65534
         fsGroup: 65534
+        supplementalGroups:
+        - 1
       containers:
       - image: {{ index .Values.images "calico-typha" }}
         name: calico-typha

--- a/charts/internal/calico/templates/typha/psp-gardener-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/psp-gardener-calico-typha.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.typha.enabled }}
+{{- if and (.Values.config.typha.enabled) (not .Values.pspDisabled) }}
 ---
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy

--- a/charts/internal/calico/templates/typha/rolebinding-garden-psp-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/rolebinding-garden-psp-calico-typha.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.typha.enabled }}
+{{- if and (.Values.config.typha.enabled) (not .Values.pspDisabled) }}
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding

--- a/charts/internal/calico/values.yaml
+++ b/charts/internal/calico/values.yaml
@@ -38,3 +38,5 @@ vpa:
   enabled: false
 
 # nodeSelector: {}
+
+pspDisabled: false

--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -150,7 +150,7 @@ var _ = Describe("Chart package test", func() {
 
 	Describe("#ComputeCalicoChartValues", func() {
 		It("empty network config should properly render calico chart values", func() {
-			values, err := charts.ComputeCalicoChartValues(network, networkConfigNil, false, kubernetesVersion, false, true)
+			values, err := charts.ComputeCalicoChartValues(network, networkConfigNil, false, kubernetesVersion, false, true, true)
 			Expect(err).To(BeNil())
 			Expect(values).To(Equal(map[string]interface{}{
 				"images": map[string]interface{}{
@@ -203,6 +203,7 @@ var _ = Describe("Chart package test", func() {
 						"autoDetectionMethod": nil,
 					},
 				},
+				"pspDisabled": true,
 			}))
 
 		})
@@ -210,7 +211,7 @@ var _ = Describe("Chart package test", func() {
 
 	Describe("#ComputeCalicoChartValues", func() {
 		It("should disable felix ip in ip and set pool mode to never when setting backend to none", func() {
-			values, err := charts.ComputeCalicoChartValues(network, networkConfigBackendNone, false, kubernetesVersion, false, true)
+			values, err := charts.ComputeCalicoChartValues(network, networkConfigBackendNone, false, kubernetesVersion, false, true, false)
 			Expect(err).To(BeNil())
 			Expect(values).To(Equal(map[string]interface{}{
 				"images": map[string]interface{}{
@@ -263,13 +264,14 @@ var _ = Describe("Chart package test", func() {
 						"autoDetectionMethod": nil,
 					},
 				},
+				"pspDisabled": false,
 			}))
 		})
 	})
 
 	Describe("#ComputeAllCalicoChartValues", func() {
 		It("should correctly compute all of the calico chart values", func() {
-			values, err := charts.ComputeCalicoChartValues(network, networkConfigAll, false, kubernetesVersion, true, true)
+			values, err := charts.ComputeCalicoChartValues(network, networkConfigAll, false, kubernetesVersion, true, true, false)
 			Expect(err).To(BeNil())
 			Expect(values).To(Equal(map[string]interface{}{
 				"images": map[string]interface{}{
@@ -322,11 +324,12 @@ var _ = Describe("Chart package test", func() {
 						"autoDetectionMethod": *networkConfigAll.IPv4.AutoDetectionMethod,
 					},
 				},
+				"pspDisabled": false,
 			}))
 		})
 
 		It("should correctly compute all of the calico chart values with mtu", func() {
-			values, err := charts.ComputeCalicoChartValues(network, networkConfigAllMTU, false, kubernetesVersion, false, true)
+			values, err := charts.ComputeCalicoChartValues(network, networkConfigAllMTU, false, kubernetesVersion, false, true, false)
 			Expect(err).To(BeNil())
 			Expect(values).To(Equal(map[string]interface{}{
 				"images": map[string]interface{}{
@@ -379,11 +382,12 @@ var _ = Describe("Chart package test", func() {
 						"autoDetectionMethod": *networkConfigAll.IPv4.AutoDetectionMethod,
 					},
 				},
+				"pspDisabled": false,
 			}))
 		})
 
 		It("should correctly compute all of the calico chart values with ebpf dataplane enabled and kube-proxy disabled", func() {
-			values, err := charts.ComputeCalicoChartValues(network, networkConfigAllEBPFDataplane, false, kubernetesVersion, false, false)
+			values, err := charts.ComputeCalicoChartValues(network, networkConfigAllEBPFDataplane, false, kubernetesVersion, false, false, false)
 			Expect(err).To(BeNil())
 			Expect(values).To(Equal(map[string]interface{}{
 				"images": map[string]interface{}{
@@ -436,13 +440,14 @@ var _ = Describe("Chart package test", func() {
 						"autoDetectionMethod": *networkConfigAll.IPv4.AutoDetectionMethod,
 					},
 				},
+				"pspDisabled": false,
 			}))
 		})
 	})
 
 	Describe("#ComputeAllCalicoChartValues", func() {
 		It("should respect deprecated fields in order to keep backwards compatibility", func() {
-			values, err := charts.ComputeCalicoChartValues(network, networkConfigDeprecated, false, kubernetesVersion, true, true)
+			values, err := charts.ComputeCalicoChartValues(network, networkConfigDeprecated, false, kubernetesVersion, true, true, false)
 			Expect(err).To(BeNil())
 			Expect(values).To(Equal(map[string]interface{}{
 				"images": map[string]interface{}{
@@ -495,13 +500,14 @@ var _ = Describe("Chart package test", func() {
 						"autoDetectionMethod": *networkConfigDeprecated.IPAutoDetectionMethod,
 					},
 				},
+				"pspDisabled": false,
 			}))
 		})
 	})
 
 	Describe("#ActivatesSystemComponentNodeSelector", func() {
 		It("should set a nodeSelector when desired", func() {
-			values, err := charts.ComputeCalicoChartValues(network, networkConfigNil, true, kubernetesVersion, false, true)
+			values, err := charts.ComputeCalicoChartValues(network, networkConfigNil, true, kubernetesVersion, false, true, false)
 			Expect(err).To(BeNil())
 			Expect(values).To(Equal(map[string]interface{}{
 				"images": map[string]interface{}{
@@ -557,13 +563,14 @@ var _ = Describe("Chart package test", func() {
 				"nodeSelector": map[string]string{
 					"worker.gardener.cloud/system-components": "true",
 				},
+				"pspDisabled": false,
 			}))
 		})
 	})
 
 	Describe("#ComputeInvalidCalicoChartValues", func() {
 		It("should error on invalid config value", func() {
-			_, err := charts.ComputeCalicoChartValues(network, networkConfigInvalid, false, kubernetesVersion, true, true)
+			_, err := charts.ComputeCalicoChartValues(network, networkConfigInvalid, false, kubernetesVersion, true, true, false)
 			Expect(err).To(Equal(fmt.Errorf("error when generating calico config: unsupported value for backend: invalid")))
 		})
 	})
@@ -591,7 +598,7 @@ var _ = Describe("Chart package test", func() {
 				},
 			}, nil)
 
-			_, err := charts.RenderCalicoChart(mockChartRenderer, network, networkConfigNil, false, kubernetesVersion, false, true)
+			_, err := charts.RenderCalicoChart(mockChartRenderer, network, networkConfigNil, false, kubernetesVersion, false, true, false)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -143,7 +143,15 @@ func (c *calicoConfig) toMap() (map[string]interface{}, error) {
 }
 
 // ComputeCalicoChartValues computes the values for the calico chart.
-func ComputeCalicoChartValues(network *extensionsv1alpha1.Network, config *calicov1alpha1.NetworkConfig, workerSystemComponentsActivated bool, kubernetesVersion string, wantsVPA bool, kubeProxyEnabled bool) (map[string]interface{}, error) {
+func ComputeCalicoChartValues(
+	network *extensionsv1alpha1.Network,
+	config *calicov1alpha1.NetworkConfig,
+	workerSystemComponentsActivated bool,
+	kubernetesVersion string,
+	wantsVPA bool,
+	kubeProxyEnabled bool,
+	isPSPDisabled bool,
+) (map[string]interface{}, error) {
 	typedConfig, err := generateChartValues(config, kubeProxyEnabled)
 	if err != nil {
 		return nil, fmt.Errorf("error when generating calico config: %v", err)
@@ -168,7 +176,8 @@ func ComputeCalicoChartValues(network *extensionsv1alpha1.Network, config *calic
 		"global": map[string]string{
 			"podCIDR": network.Spec.PodCIDR,
 		},
-		"config": calicoConfig,
+		"config":      calicoConfig,
+		"pspDisabled": isPSPDisabled,
 	}
 	if workerSystemComponentsActivated {
 		calicoChartValues["nodeSelector"] = map[string]string{

--- a/pkg/charts/values.go
+++ b/pkg/charts/values.go
@@ -26,8 +26,17 @@ import (
 const CalicoConfigKey = "config.yaml"
 
 // RenderCalicoChart renders the calico chart with the given values.
-func RenderCalicoChart(renderer chartrenderer.Interface, network *extensionsv1alpha1.Network, config *calicov1alpha1.NetworkConfig, workerSystemComponentsActivated bool, kubernetesVersion string, wantsVPA bool, kubeProxyEnabled bool) ([]byte, error) {
-	values, err := ComputeCalicoChartValues(network, config, workerSystemComponentsActivated, kubernetesVersion, wantsVPA, kubeProxyEnabled)
+func RenderCalicoChart(
+	renderer chartrenderer.Interface,
+	network *extensionsv1alpha1.Network,
+	config *calicov1alpha1.NetworkConfig,
+	workerSystemComponentsActivated bool,
+	kubernetesVersion string,
+	wantsVPA bool,
+	kubeProxyEnabled bool,
+	isPSPDisabled bool,
+) ([]byte, error) {
+	values, err := ComputeCalicoChartValues(network, config, workerSystemComponentsActivated, kubernetesVersion, wantsVPA, kubeProxyEnabled, isPSPDisabled)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -22,7 +22,6 @@ import (
 	calicov1alpha1helper "github.com/gardener/gardener-extension-networking-calico/pkg/apis/calico/v1alpha1/helper"
 	"github.com/gardener/gardener-extension-networking-calico/pkg/calico"
 	"github.com/gardener/gardener-extension-networking-calico/pkg/charts"
-
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -123,13 +122,23 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, network *extens
 	if cluster.Shoot.Spec.Kubernetes.KubeProxy != nil && cluster.Shoot.Spec.Kubernetes.KubeProxy.Enabled != nil {
 		kubeProxyEnabled = *cluster.Shoot.Spec.Kubernetes.KubeProxy.Enabled
 	}
+
 	// Create shoot chart renderer
 	chartRenderer, err := a.chartRendererFactory.NewChartRendererForShoot(cluster.Shoot.Spec.Kubernetes.Version)
 	if err != nil {
 		return fmt.Errorf("could not create chart renderer for shoot '%s': %w", network.Namespace, err)
 	}
 
-	calicoChart, err := charts.RenderCalicoChart(chartRenderer, network, networkConfig, activateSystemComponentsNodeSelector(cluster.Shoot), cluster.Shoot.Spec.Kubernetes.Version, gardencorev1beta1helper.ShootWantsVerticalPodAutoscaler(cluster.Shoot), kubeProxyEnabled)
+	calicoChart, err := charts.RenderCalicoChart(
+		chartRenderer,
+		network,
+		networkConfig,
+		activateSystemComponentsNodeSelector(cluster.Shoot),
+		cluster.Shoot.Spec.Kubernetes.Version,
+		gardencorev1beta1helper.ShootWantsVerticalPodAutoscaler(cluster.Shoot),
+		kubeProxyEnabled,
+		gardencorev1beta1helper.IsPSPDisabled(cluster.Shoot),
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
`PodSecurityPolicy` is deprecated and will be disabled in kubernetes v1.25+.
End-users are provided an option to migrate their PSPs before upgrading and disable the `PodSecurityPolicy` admission plugin in the ShootSpec. 
In that case, we should stop deploying our PSPs as well.

- This PR adapts the mutating fields of the existing PSPs in the PodSpec. 
- Stop deploying PSPs if the plugin is disabled in the Shoot.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5250

**Special notes for your reviewer**:
/hold
Depends on https://github.com/gardener/gardener-extension-networking-calico/pull/201

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Please make sure you're running gardener@v1.52 or above before upgrading to this version.
```
