### PR TITLE
Default seccomp profile for calico components

### DIFF
--- a/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
@@ -48,6 +48,11 @@ spec:
       priorityClassName: system-cluster-critical
       # Make sure to not use the coredns for DNS resolution.
       dnsPolicy: Default
+      {{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      {{- end }}
       containers:
         - name: calico-kube-controllers
           image: {{ index .Values.images "calico-kube-controllers" }}

--- a/charts/internal/calico/templates/kube-controller/psp-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/psp-calico-kube-controllers.yaml
@@ -3,6 +3,9 @@
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
 metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   name: gardener.kube-system.calico-kube-controllers
 spec:
   volumes:

--- a/charts/internal/calico/templates/node-cpva/deployment-calico-node-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/node-cpva/deployment-calico-node-vertical-autoscaler.yaml
@@ -33,6 +33,10 @@ spec:
         fsGroup: 1
         supplementalGroups:
         - 1
+        {{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+        {{- end }}
       # Make sure to not use the coredns for DNS resolution.
       dnsPolicy: Default
       containers:

--- a/charts/internal/calico/templates/node-cpva/psp-gardener-node-cpva.yaml
+++ b/charts/internal/calico/templates/node-cpva/psp-gardener-node-cpva.yaml
@@ -3,6 +3,9 @@
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
 metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   name: gardener.kube-system.calico-node-cpva
 spec:
   volumes:

--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -45,6 +45,11 @@ spec:
         - effect: NoExecute
           operator: Exists
       serviceAccountName: calico-node
+      {{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      {{- end }}
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0

--- a/charts/internal/calico/templates/node/psp-calico.yaml
+++ b/charts/internal/calico/templates/node/psp-calico.yaml
@@ -3,6 +3,9 @@
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
 metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   name: gardener.kube-system.calico
 spec:
   privileged: true
@@ -28,6 +31,7 @@ spec:
   - pathPrefix: /var/lib/kubelet/volumeplugins/nodeagent~uds
   - pathPrefix: /var/log/calico/cni
   - pathPrefix: /sys/fs/
+  - pathPrefix: /proc
   runAsUser:
     rule: RunAsAny
   seLinux:

--- a/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
@@ -36,6 +36,10 @@ spec:
         fsGroup: 65532
         runAsUser: 65532
         runAsNonRoot: true
+        {{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+        {{- end }}
       containers:
         - image: {{ index .Values.images "calico-cpa" }}
           name: autoscaler

--- a/charts/internal/calico/templates/typha-cpha/psp-gardener-typha-cpa.yaml
+++ b/charts/internal/calico/templates/typha-cpha/psp-gardener-typha-cpa.yaml
@@ -3,6 +3,9 @@
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
 metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   name: gardener.kube-system.typha-cpa
 spec:
   volumes:

--- a/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
@@ -37,6 +37,10 @@ spec:
         supplementalGroups:
         - 1
         fsGroup: 1
+        {{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+        {{- end }}
       containers:
         - image:  {{ index .Values.images "calico-cpva" }}
           name: autoscaler

--- a/charts/internal/calico/templates/typha-cpva/psp-gardener-typha-cpva.yaml
+++ b/charts/internal/calico/templates/typha-cpva/psp-gardener-typha-cpva.yaml
@@ -3,6 +3,9 @@
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
 metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   name: gardener.kube-system.typha-cpva
 spec:
   volumes:

--- a/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
@@ -77,6 +77,10 @@ spec:
         fsGroup: 65534
         supplementalGroups:
         - 1
+        {{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+        {{- end }}
       containers:
       - image: {{ index .Values.images "calico-typha" }}
         name: calico-typha

--- a/charts/internal/calico/templates/typha/psp-gardener-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/psp-gardener-calico-typha.yaml
@@ -3,6 +3,9 @@
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
 metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   name: gardener.kube-system.calico-typha
 spec:
   volumes:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR adds a seccomp profile to calico workload running in the shoot.
It also allows `/proc` as allowed host path in the psp definition for `calico-node`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Pods for `calico-kube-controllers`, `calico-node`, `calico-node-vertical-autoscaler`, `calico-typha`, `calico-typha-horizontal-autoscaler` and `calico-typha-vertical-autoscaler` components now have their seccomp profile set to "RuntimeDefault". 
```
