### PR TITLE
Update cluster-proportional-autoscaler image

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -58,7 +58,7 @@ images:
 - name: calico-cpa
   sourceRepository: github.com/kubernetes-sigs/cluster-proportional-autoscaler
   repository: k8s.gcr.io/cpa/cluster-proportional-autoscaler
-  tag: 1.8.5
+  tag: 1.8.6
 - name: calico-cpva
   sourceRepository: github.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler
   repository: k8s.gcr.io/cpa/cpvpa


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following image is updated:
- k8s.gcr.io/cpa/cluster-proportional-autoscaler: v1.8.5 -> v1.8.6
```
