### PR TITLE
Fix typos in docs/usage-as-operator.md

### DIFF
--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -8,9 +8,9 @@ This document explains configuration options supported by the networking-calico 
 
 ##### Motivation
 
-Running containers in privileged mode is not recommended as privileged containers run with all [linux capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html) enabled and can access the host's resources. Running containers in privileged mode opens number of security thread such as breakout to underlyining host OS.
+Running containers in privileged mode is not recommended as privileged containers run with all [linux capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html) enabled and can access the host's resources. Running containers in privileged mode opens number of security threats such as breakout to underlying host OS.
 
-##### Support for non-provileged and non-root mode
+##### Support for non-privileged and non-root mode
 
 The Calico project has a preliminary support for running the calico-node component in non-privileged mode (see [this guide](https://projectcalico.docs.tigera.io/security/non-privileged)). Similar to [Tigera Calico operator](https://github.com/tigera/operator) the networking-calico extension can also run calico-node in non-privileged and non-root mode. This feature is controller via feature gate named `NonPrivilegedCalicoNode`. The feature gates are configured in the [ControllerConfiguration](../example/00-componentconfig.yaml) of networking-calico. The corresponding ControllerDeployment configuration that enables the `NonPrivilegedCalicoNode` would look like:
 


### PR DESCRIPTION
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
