### PR TITLE
Configure SecurityContext for Calico-Kube-Controller

### DIFF
--- a/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
@@ -84,4 +84,6 @@ spec:
                 - -r
             periodSeconds: 10
             timeoutSeconds: 10
+          securityContext:
+            readOnlyRootFilesystem: false
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR sets the required `securityContext.readOnlyRootFilesytem: false` for the `calico-kube-controller` deployment. On some occasions (in our case in combination with `PodSecurityPolicies`), the field is defaulted to `true` which hinders the controller from starting properly:

```
2022-10-26 12:13:15.930 [ERROR][1] status.go 138: Failed to write readiness file: open /status/status.json: read-only file system
2022-10-26 12:13:15.931 [WARNING][1] status.go 66: Failed to write status error=open /status/status.json: read-only file system
``` 

**Special notes for your reviewer**:
/cc @dimityrmirchev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `securityContext.readOnlyRootFilesystem` is now explicitly set to `false` for the `calico-kube-controller` container. In certain setups, the field was defaulted to `true` which prevented the pod from starting properly.
```
