### PR TITLE
omit backend field when empty

### DIFF
--- a/pkg/apis/calico/v1alpha1/types_network.go
+++ b/pkg/apis/calico/v1alpha1/types_network.go
@@ -69,7 +69,7 @@ type NetworkConfig struct {
 	metav1.TypeMeta `json:",inline"`
 	// Backend defines whether a backend should be used or not (e.g., bird or none)
 	// +optional
-	Backend *Backend `json:"backend"`
+	Backend *Backend `json:"backend,omitempty"`
 	// IPAM to use for the Calico Plugin (e.g., host-local or Calico)
 	// +optional
 	IPAM *IPAM `json:"ipam,omitempty"`


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Backend field is omitted when not specified.
This will avoid setting `backend: null` when the shoot mutator webhook in the infrastructure extension is called which might lead to error during validation.

```
error: error validating "STDIN": error validating data: unknown object type "nil" in Shoot.spec.networking.providerConfig.backend; if you choose to ignore these errors, turn validation off with --validate=false
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Backend field is omitted when not specified.
```
