### PR TITLE
Drop support for kubernetes < 1.20 for calico extension

### DIFF
--- a/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
@@ -48,11 +48,9 @@ spec:
       priorityClassName: system-cluster-critical
       # Make sure to not use the coredns for DNS resolution.
       dnsPolicy: Default
-      {{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-      {{- end }}
       containers:
         - name: calico-kube-controllers
           image: {{ index .Values.images "calico-kube-controllers" }}

--- a/charts/internal/calico/templates/node-cpva/deployment-calico-node-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/node-cpva/deployment-calico-node-vertical-autoscaler.yaml
@@ -33,10 +33,8 @@ spec:
         fsGroup: 1
         supplementalGroups:
         - 1
-        {{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
         seccompProfile:
           type: RuntimeDefault
-        {{- end }}
       # Make sure to not use the coredns for DNS resolution.
       dnsPolicy: Default
       containers:

--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -45,11 +45,9 @@ spec:
         - effect: NoExecute
           operator: Exists
       serviceAccountName: calico-node
-      {{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-      {{- end }}
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0

--- a/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
@@ -36,10 +36,8 @@ spec:
         fsGroup: 65532
         runAsUser: 65532
         runAsNonRoot: true
-        {{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
         seccompProfile:
           type: RuntimeDefault
-        {{- end }}
       containers:
         - image: {{ index .Values.images "calico-cpa" }}
           name: autoscaler

--- a/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
@@ -37,10 +37,8 @@ spec:
         supplementalGroups:
         - 1
         fsGroup: 1
-        {{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
         seccompProfile:
           type: RuntimeDefault
-        {{- end }}
       containers:
         - image:  {{ index .Values.images "calico-cpva" }}
           name: autoscaler

--- a/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
@@ -68,10 +68,8 @@ spec:
         fsGroup: 65534
         supplementalGroups:
         - 1
-        {{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
         seccompProfile:
           type: RuntimeDefault
-        {{- end }}
       containers:
       - image: {{ index .Values.images "calico-typha" }}
         imagePullPolicy: IfNotPresent

--- a/example/20-network.yaml
+++ b/example/20-network.yaml
@@ -28,7 +28,7 @@ spec:
       dns:
         domain: foo.bar.example.com
       kubernetes:
-        version: 1.15.1
+        version: 1.24.8
     status:
       lastOperation:
         state: Succeeded

--- a/hack/api-reference/calico.json
+++ b/hack/api-reference/calico.json
@@ -9,7 +9,7 @@
     "externalPackages": [
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         }
     ],
     "typeDisplayNamePrefixOverrides": {

--- a/hack/api-reference/config.json
+++ b/hack/api-reference/config.json
@@ -17,7 +17,7 @@
         },
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
             "typeMatchPrefix": "github.com/gardener/gardener/extensions/pkg/controller/healthcheck/config",

--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -42,7 +42,7 @@ var (
 
 var _ = Describe("Chart package test", func() {
 	var (
-		kubernetesVersion                               = "1.18.0"
+		kubernetesVersion                               = "1.20.0"
 		podCIDR                                         = calicov1alpha1.CIDR("12.0.0.0/8")
 		crossSubnet                                     = calicov1alpha1.CrossSubnet
 		always                                          = calicov1alpha1.Always


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
Drop support for kubernetes < 1.20.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6911

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Calico networking no longer supports Shoots with Кubernetes version < 1.20.
```
