### PR TITLE
Drop nodeSelector and tolerations from Shoot System Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ Finally after successful reconciliation an output similar to the one below shoul
       kind: NetworkStatus
 ```
 
+## Compatibility
+
+The following lists known compatibility issues of this extension controller with other Gardener components.
+
+| Calico Extension | Gardener | Action | Notes |
+| ------------- | -------- | ------ |  --- |
+| `>= v1.28.0` | `< v1.63.0` | Please first update Gardener components to `>= v1.63.0`. | Without the mentioned minimum Gardener version, Calico `Pod`s are not only scheduled to dedicated system component nodes in the shoot cluster.
 ----
 
 ## How to start using or developing this extension controller locally

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The following table lists known compatibility issues of this extension controlle
 
 | Calico Extension | Gardener | Action | Notes |
 | ------------- | -------- | ------ |  --- |
-| `>= v1.28.0` | `< v1.63.0` | Please first update Gardener components to `>= v1.63.0`. | Without the mentioned minimum Gardener version, Calico `Pod`s are not only scheduled to dedicated system component nodes in the shoot cluster.
+| `>= v1.30.0` | `< v1.63.0` | Please first update Gardener components to `>= v1.63.0`. | Without the mentioned minimum Gardener version, Calico `Pod`s are not only scheduled to dedicated system component nodes in the shoot cluster.
 ----
 
 ## How to start using or developing this extension controller locally

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Finally after successful reconciliation an output similar to the one below shoul
 
 ## Compatibility
 
-The following lists known compatibility issues of this extension controller with other Gardener components.
+The following table lists known compatibility issues of this extension controller with other Gardener components.
 
 | Calico Extension | Gardener | Action | Notes |
 | ------------- | -------- | ------ |  --- |

--- a/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
@@ -35,11 +35,6 @@ spec:
       # Make sure kube-controllers gets scheduled on all nodes.
       - effect: NoSchedule
         operator: Exists
-      # Mark the pod as a critical add-on for rescheduling.
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoExecute
-        operator: Exists
       serviceAccountName: calico-kube-controllers
       priorityClassName: system-cluster-critical
       # Make sure to not use the coredns for DNS resolution.

--- a/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
+++ b/charts/internal/calico/templates/kube-controller/deployment-calico-kube-controllers.yaml
@@ -31,10 +31,6 @@ spec:
         k8s-app: calico-kube-controllers
         gardener.cloud/role: system-component
     spec:
-      {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-      {{- end }}
       tolerations:
       # Make sure kube-controllers gets scheduled on all nodes.
       - effect: NoSchedule

--- a/charts/internal/calico/templates/node-cpva/deployment-calico-node-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/node-cpva/deployment-calico-node-vertical-autoscaler.yaml
@@ -22,10 +22,6 @@ spec:
         networking.gardener.cloud/to-apiserver: allowed
         networking.gardener.cloud/to-dns: allowed
     spec:
-      {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-      {{- end }}
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true

--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -39,11 +39,6 @@ spec:
         # Make sure calico-node gets scheduled on all nodes.
         - effect: NoSchedule
           operator: Exists
-        # Mark the pod as a critical add-on for rescheduling.
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - effect: NoExecute
-          operator: Exists
       serviceAccountName: calico-node
       securityContext:
         seccompProfile:

--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -39,6 +39,8 @@ spec:
         # Make sure calico-node gets scheduled on all nodes.
         - effect: NoSchedule
           operator: Exists
+        - effect: NoExecute
+          operator: Exists
       serviceAccountName: calico-node
       securityContext:
         seccompProfile:

--- a/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
@@ -24,10 +24,6 @@ spec:
         origin: gardener
         k8s-app: calico-typha-autoscaler
     spec:
-      {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-      {{- end }}
       priorityClassName: gardener-shoot-system-800
       # Make sure to not use the coredns for DNS resolution.
       dnsPolicy: Default

--- a/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
@@ -24,10 +24,6 @@ spec:
         origin: gardener
         k8s-app: calico-typha-autoscaler
     spec:
-      {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-      {{- end }}
       priorityClassName: gardener-shoot-system-800
       # Make sure to not use the coredns for DNS resolution.
       dnsPolicy: Default

--- a/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
@@ -53,11 +53,6 @@ spec:
       # Make sure typha gets scheduled on all nodes.
       - effect: NoSchedule
         operator: Exists
-      # Mark the pod as a critical add-on for rescheduling.
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoExecute
-        operator: Exists
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       hostNetwork: true

--- a/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
+++ b/charts/internal/calico/templates/typha/deployment-calico-typha.yaml
@@ -49,10 +49,6 @@ spec:
         gardener.cloud/role: system-component
         k8s-app: calico-typha
     spec:
-      {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-      {{- end }}
       tolerations:
       # Make sure typha gets scheduled on all nodes.
       - effect: NoSchedule

--- a/charts/internal/calico/values.yaml
+++ b/charts/internal/calico/values.yaml
@@ -41,6 +41,4 @@ images:
 vpa:
   enabled: false
 
-# nodeSelector: {}
-
 pspDisabled: false

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"strconv"
 
-	gardenv1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-
 	calicov1alpha1 "github.com/gardener/gardener-extension-networking-calico/pkg/apis/calico/v1alpha1"
 	"github.com/gardener/gardener-extension-networking-calico/pkg/calico"
 	"github.com/gardener/gardener-extension-networking-calico/pkg/imagevector"
@@ -148,7 +146,6 @@ func (c *calicoConfig) toMap() (map[string]interface{}, error) {
 func ComputeCalicoChartValues(
 	network *extensionsv1alpha1.Network,
 	config *calicov1alpha1.NetworkConfig,
-	workerSystemComponentsActivated bool,
 	kubernetesVersion string,
 	wantsVPA bool,
 	kubeProxyEnabled bool,
@@ -183,11 +180,6 @@ func ComputeCalicoChartValues(
 		},
 		"config":      calicoConfig,
 		"pspDisabled": isPSPDisabled,
-	}
-	if workerSystemComponentsActivated {
-		calicoChartValues["nodeSelector"] = map[string]string{
-			gardenv1beta1constants.LabelWorkerPoolSystemComponents: "true",
-		}
 	}
 
 	if config != nil && config.Overlay != nil {

--- a/pkg/charts/values.go
+++ b/pkg/charts/values.go
@@ -30,7 +30,6 @@ func RenderCalicoChart(
 	renderer chartrenderer.Interface,
 	network *extensionsv1alpha1.Network,
 	config *calicov1alpha1.NetworkConfig,
-	workerSystemComponentsActivated bool,
 	kubernetesVersion string,
 	wantsVPA bool,
 	kubeProxyEnabled bool,
@@ -38,7 +37,7 @@ func RenderCalicoChart(
 	nonPrivileged bool,
 	nodeCIDR string,
 ) ([]byte, error) {
-	values, err := ComputeCalicoChartValues(network, config, workerSystemComponentsActivated, kubernetesVersion, wantsVPA, kubeProxyEnabled, isPSPDisabled, nonPrivileged, nodeCIDR)
+	values, err := ComputeCalicoChartValues(network, config, kubernetesVersion, wantsVPA, kubeProxyEnabled, isPSPDisabled, nonPrivileged, nodeCIDR)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gardener/gardener-extension-networking-calico/pkg/charts"
 	"github.com/gardener/gardener-extension-networking-calico/pkg/features"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -55,19 +54,6 @@ func calicoSecret(cl client.Client, calicoConfig []byte, namespace string) (*bui
 	return builder.NewSecret(cl).
 		WithKeyValues(map[string][]byte{charts.CalicoConfigKey: calicoConfig}).
 		WithNamespacedName(namespace, CalicoConfigSecretName), withLocalObjectRefs(CalicoConfigSecretName)
-}
-
-func activateSystemComponentsNodeSelector(shoot *gardencorev1beta1.Shoot) bool {
-	var atLeastOneWorkerPoolHasSystemComponents bool
-
-	for _, worker := range shoot.Spec.Provider.Workers {
-		if gardencorev1beta1helper.SystemComponentsAllowed(&worker) {
-			atLeastOneWorkerPoolHasSystemComponents = true
-			break
-		}
-	}
-
-	return atLeastOneWorkerPoolHasSystemComponents
 }
 
 func applyMonitoringConfig(ctx context.Context, seedClient client.Client, chartApplier gardenerkubernetes.ChartApplier, network *extensionsv1alpha1.Network, deleteChart bool) error {
@@ -144,7 +130,6 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, network *extens
 		chartRenderer,
 		network,
 		networkConfig,
-		activateSystemComponentsNodeSelector(cluster.Shoot),
 		cluster.Shoot.Spec.Kubernetes.Version,
 		gardencorev1beta1helper.ShootWantsVerticalPodAutoscaler(cluster.Shoot),
 		kubeProxyEnabled,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
After the integration of https://github.com/gardener/gardener/pull/7204, this PR cleans up relevant deployments of Shoot System Components:
- removes `nodeSelector`
- removes all `CriticalAddonsOnly` tolerations (not related to [#7204](https://github.com/gardener/gardener/pull/7204) but removed along the way)
- adds `NoExecute` toleration for Calico-Node as this pod is supposed to run at all times or it doesn't make much sense to evict it (please double check @ScheererJ @DockToFuture)


Please see the individual commit messages for more information.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7103

**Special notes for your reviewer**:
~Remains in draft until Gardener `v1.63` is released.~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Node selectors and general tolerations were removed from Calico deployments applied to the shoot cluster in favor of Gardener's automatic handling added in https://github.com/gardener/gardener/pull/7204.
This version of the Calico extension expects a minimum Gardener version `v1.63`.
```
