### PR TITLE
Enable source network address translation to infrastructure dns per default if overlay network is disabled.

### DIFF
--- a/hack/api-reference/calico.md
+++ b/hack/api-reference/calico.md
@@ -149,7 +149,7 @@ SnatToUpstreamDNS
 </td>
 <td>
 <em>(Optional)</em>
-<p>SnatToUpstreamDNS enables the masquerading of packets to the upstream dns server</p>
+<p>SnatToUpstreamDNS enables the masquerading of packets to the upstream dns server (default: enabled)</p>
 </td>
 </tr>
 <tr>
@@ -406,7 +406,7 @@ bool
 <a href="#calico.networking.extensions.gardener.cloud/v1alpha1.NetworkConfig">NetworkConfig</a>)
 </p>
 <p>
-<p>SnatToUpstreamDNS  enables the masquerading of packets to the upstream dns server</p>
+<p>SnatToUpstreamDNS enables the masquerading of packets to the upstream dns server</p>
 </p>
 <table>
 <thead>

--- a/pkg/apis/calico/types_network.go
+++ b/pkg/apis/calico/types_network.go
@@ -77,7 +77,7 @@ type NetworkConfig struct {
 	EbpfDataplane *EbpfDataplane
 	// Overlay enables the network overlay
 	Overlay *Overlay
-	// SnatToUpstreamDNS enables the masquerading of packets to the upstream dns server
+	// SnatToUpstreamDNS enables the masquerading of packets to the upstream dns server (default: enabled)
 	SnatToUpstreamDNS *SnatToUpstreamDNS
 
 	// DEPRECATED.
@@ -126,7 +126,7 @@ type Overlay struct {
 	Enabled bool
 }
 
-// SnatToUpstreamDNS  enables the masquerading of packets to the upstream dns server
+// SnatToUpstreamDNS enables the masquerading of packets to the upstream dns server
 type SnatToUpstreamDNS struct {
 	Enabled bool
 }

--- a/pkg/apis/calico/v1alpha1/types_network.go
+++ b/pkg/apis/calico/v1alpha1/types_network.go
@@ -88,7 +88,7 @@ type NetworkConfig struct {
 	// Overlay enables the network overlay
 	// +optional
 	Overlay *Overlay `json:"overlay,omitempty"`
-	// SnatToUpstreamDNS enables the masquerading of packets to the upstream dns server
+	// SnatToUpstreamDNS enables the masquerading of packets to the upstream dns server (default: enabled)
 	// +optional
 	SnatToUpstreamDNS *SnatToUpstreamDNS `json:"snatToUpstreamDNS,omitempty"`
 
@@ -141,7 +141,7 @@ type Overlay struct {
 	Enabled bool `json:"enabled"`
 }
 
-// SnatToUpstreamDNS  enables the masquerading of packets to the upstream dns server
+// SnatToUpstreamDNS enables the masquerading of packets to the upstream dns server
 type SnatToUpstreamDNS struct {
 	Enabled bool `json:"enabled"`
 }

--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -480,9 +480,10 @@ var _ = Describe("Chart package test", func() {
 					"calico-cpva":             imagevector.ClusterProportionalVerticalAutoscalerImage(kubernetesVersion),
 				},
 				"global": map[string]string{
-					"podCIDR":        network.Spec.PodCIDR,
-					"nodeCIDR":       string(nodeCIDR),
-					"overlayEnabled": "false",
+					"podCIDR":                  network.Spec.PodCIDR,
+					"nodeCIDR":                 string(nodeCIDR),
+					"overlayEnabled":           "false",
+					"snatToUpstreamDNSEnabled": "true",
 				},
 				"vpa": map[string]interface{}{
 					"enabled": true,

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -186,8 +186,13 @@ func ComputeCalicoChartValues(
 		calicoChartValues["global"].(map[string]string)["overlayEnabled"] = strconv.FormatBool(config.Overlay.Enabled)
 	}
 
-	if config != nil && config.Overlay != nil && !config.Overlay.Enabled && config.SnatToUpstreamDNS != nil {
-		calicoChartValues["global"].(map[string]string)["snatToUpstreamDNSEnabled"] = strconv.FormatBool(config.SnatToUpstreamDNS.Enabled)
+	if config != nil && config.Overlay != nil && !config.Overlay.Enabled {
+		// Overlay is disabled => enable source NAT to upstream DNS per default
+		snatToUpstreamDNS := true
+		if config.SnatToUpstreamDNS != nil {
+			snatToUpstreamDNS = config.SnatToUpstreamDNS.Enabled
+		}
+		calicoChartValues["global"].(map[string]string)["snatToUpstreamDNSEnabled"] = strconv.FormatBool(snatToUpstreamDNS)
 	}
 
 	return calicoChartValues, nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Enable source network address translation to infrastructure dns per default if overlay network is disabled.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Shoot clusters without overlay network have source network address translation enabled per default to the infrastructure dns
```
