### PR TITLE
Allow non-specified node cidr.

### DIFF
--- a/charts/internal/calico/templates/ippool/ippool.yaml
+++ b/charts/internal/calico/templates/ippool/ippool.yaml
@@ -31,6 +31,7 @@ spec:
   natOutgoing: true
   nodeSelector: all()
   vxlanMode: Never
+{{- if .Values.global.nodeCIDR }}
 ---
 apiVersion: crd.projectcalico.org/v1
 kind: IPPool
@@ -39,4 +40,5 @@ metadata:
 spec:
   cidr: "{{ .Values.global.nodeCIDR }}"
   disabled: true
+{{- end }}
 {{- end }}

--- a/charts/internal/calico/values.yaml
+++ b/charts/internal/calico/values.yaml
@@ -1,6 +1,6 @@
 global:
   podCIDR: ""
-  nodeCIDR: ""
+  #nodeCIDR: "" # Only set when available
   overlayEnabled: ""
   snatToUpstreamDNSEnabled: ""
 config:

--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -35,7 +35,6 @@ import (
 
 var (
 	trueVar    = true
-	falseVar   = false
 	mtuVar     = "1430"
 	defaultMtu = "1440"
 )
@@ -44,7 +43,8 @@ var _ = Describe("Chart package test", func() {
 	var (
 		kubernetesVersion                               = "1.20.0"
 		podCIDR                                         = calicov1alpha1.CIDR("12.0.0.0/8")
-		nodeCIDR                                        = calicov1alpha1.CIDR("10.250.0.0/8")
+		nodeCIDR                                        = "10.250.0.0/8"
+		usePodCidr                                      = calicov1alpha1.CIDR("usePodCidr")
 		crossSubnet                                     = calicov1alpha1.CrossSubnet
 		always                                          = calicov1alpha1.Always
 		never                                           = calicov1alpha1.Never
@@ -59,6 +59,7 @@ var _ = Describe("Chart package test", func() {
 
 		network                       *extensionsv1alpha1.Network
 		networkConfigNil              *calicov1alpha1.NetworkConfig
+		networkConfigNilValues        *calicov1alpha1.NetworkConfig
 		networkConfigBackendNone      *calicov1alpha1.NetworkConfig
 		networkConfigAll              *calicov1alpha1.NetworkConfig
 		networkConfigAllMTU           *calicov1alpha1.NetworkConfig
@@ -66,6 +67,15 @@ var _ = Describe("Chart package test", func() {
 		networkConfigDeprecated       *calicov1alpha1.NetworkConfig
 		networkConfigInvalid          *calicov1alpha1.NetworkConfig
 		networkConfigOverlayDisabled  *calicov1alpha1.NetworkConfig
+
+		networkConfigNilFunc              = func() *calicov1alpha1.NetworkConfig { return networkConfigNil }
+		networkConfigNilValuesFunc        = func() *calicov1alpha1.NetworkConfig { return networkConfigNilValues }
+		networkConfigBackendNoneFunc      = func() *calicov1alpha1.NetworkConfig { return networkConfigBackendNone }
+		networkConfigAllFunc              = func() *calicov1alpha1.NetworkConfig { return networkConfigAll }
+		networkConfigAllMTUFunc           = func() *calicov1alpha1.NetworkConfig { return networkConfigAllMTU }
+		networkConfigAllEBPFDataplaneFunc = func() *calicov1alpha1.NetworkConfig { return networkConfigAllEBPFDataplane }
+		networkConfigDeprecatedFunc       = func() *calicov1alpha1.NetworkConfig { return networkConfigDeprecated }
+		networkConfigOverlayDisabledFunc  = func() *calicov1alpha1.NetworkConfig { return networkConfigOverlayDisabled }
 
 		objectMeta = metav1.ObjectMeta{
 			Name:      "foo",
@@ -82,6 +92,13 @@ var _ = Describe("Chart package test", func() {
 			},
 		}
 		networkConfigNil = nil
+		networkConfigNilValues = &calicov1alpha1.NetworkConfig{
+			Backend: &backendBird,
+			IPAM: &calicov1alpha1.IPAM{
+				CIDR: &usePodCidr,
+				Type: "host-local",
+			},
+		}
 		networkConfigBackendNone = &calicov1alpha1.NetworkConfig{
 			Backend: &backendNone,
 			IPAM: &calicov1alpha1.IPAM{
@@ -164,450 +181,140 @@ var _ = Describe("Chart package test", func() {
 		}
 	})
 
+	DescribeTable("#ComputeCalicoChartValues",
+		func(config func() *calicov1alpha1.NetworkConfig, configResult func() *calicov1alpha1.NetworkConfig, wantsVPA bool,
+			kubeProxyEnabled bool, isPSPDisabled bool, mtu string, ipinip bool, bpf bool, pool string,
+			modeFunc func() string, detectionMethodFunc func() *string, nodesFunc func() *string, additionalGlobalOptions map[string]string) {
+			values, err := charts.ComputeCalicoChartValues(network, config(), kubernetesVersion, wantsVPA, kubeProxyEnabled, isPSPDisabled, false, nodesFunc())
+			Expect(err).To(BeNil())
+			expected := map[string]interface{}{
+				"images": map[string]interface{}{
+					"calico-cni":              imagevector.CalicoCNIImage(kubernetesVersion),
+					"calico-typha":            imagevector.CalicoTyphaImage(kubernetesVersion),
+					"calico-kube-controllers": imagevector.CalicoKubeControllersImage(kubernetesVersion),
+					"calico-node":             imagevector.CalicoNodeImage(kubernetesVersion),
+					"calico-podtodaemon-flex": imagevector.CalicoFlexVolumeDriverImage(kubernetesVersion),
+					"calico-cpa":              imagevector.ClusterProportionalAutoscalerImage(kubernetesVersion),
+					"calico-cpva":             imagevector.ClusterProportionalVerticalAutoscalerImage(kubernetesVersion),
+				},
+				"global": map[string]string{
+					"podCIDR": network.Spec.PodCIDR,
+				},
+				"vpa": map[string]interface{}{
+					"enabled": wantsVPA,
+				},
+				"config": map[string]interface{}{
+					"backend": string(*configResult().Backend),
+					"ipam": map[string]interface{}{
+						"type":   configResult().IPAM.Type,
+						"subnet": string(*configResult().IPAM.CIDR),
+					},
+					"typha": map[string]interface{}{
+						"enabled": trueVar,
+					},
+					"kubeControllers": map[string]interface{}{
+						"enabled": configResult().Backend != &backendNone,
+					},
+					"veth_mtu": mtu,
+					"monitoring": map[string]interface{}{
+						"enabled":          true,
+						"typhaMetricsPort": "9093",
+						"felixMetricsPort": "9091",
+					},
+					"nonPrivileged": false,
+					"felix": map[string]interface{}{
+						"ipinip": map[string]interface{}{
+							"enabled": ipinip,
+						},
+						"bpf": map[string]interface{}{
+							"enabled": bpf,
+						},
+						"bpfKubeProxyIPTablesCleanup": map[string]interface{}{
+							"enabled": !kubeProxyEnabled,
+						},
+					},
+					"ipv4": map[string]interface{}{
+						"pool":                pool,
+						"mode":                modeFunc(),
+						"autoDetectionMethod": nil,
+					},
+				},
+				"pspDisabled": isPSPDisabled,
+			}
+			if detectionMethodFunc() != nil {
+				expected["config"].(map[string]interface{})["ipv4"].(map[string]interface{})["autoDetectionMethod"] = *detectionMethodFunc()
+			}
+			for k, v := range additionalGlobalOptions {
+				expected["global"].(map[string]string)[k] = v
+			}
+			Expect(values).To(Equal(expected))
+		},
+
+		Entry("empty network config should properly render calico chart values",
+			networkConfigNilFunc, networkConfigNilValuesFunc,
+			false, true, true, defaultMtu, true, false, string(poolIPIP),
+			func() string { return string(always) }, func() *string { return nil },
+			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR}),
+		Entry("empty network config should properly render calico chart values even without node cidr",
+			networkConfigNilFunc, networkConfigNilValuesFunc,
+			false, true, true, defaultMtu, true, false, string(poolIPIP),
+			func() string { return string(always) }, func() *string { return nil },
+			func() *string { return nil }, nil),
+		Entry("should disable felix ip in ip and set pool mode to never when setting backend to none",
+			networkConfigBackendNoneFunc, networkConfigBackendNoneFunc,
+			false, true, false, defaultMtu, false, false, string(poolIPIP),
+			func() string { return string(never) }, func() *string { return nil },
+			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR}),
+		Entry("should correctly compute all of the calico chart values",
+			networkConfigAllFunc, networkConfigAllFunc,
+			true, true, false, defaultMtu, true, false, string(poolVXlan),
+			func() string { return string(*networkConfigAll.IPv4.Mode) }, func() *string { return networkConfigAll.IPv4.AutoDetectionMethod },
+			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR}),
+		Entry("should correctly compute all of the calico chart values with mtu",
+			networkConfigAllMTUFunc, networkConfigAllMTUFunc,
+			false, true, false, mtuVar, true, false, string(poolVXlan),
+			func() string { return string(*networkConfigAll.IPv4.Mode) }, func() *string { return networkConfigAll.IPv4.AutoDetectionMethod },
+			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR}),
+		Entry("should correctly compute all of the calico chart values with ebpf dataplane enabled and kube-proxy disabled",
+			networkConfigAllEBPFDataplaneFunc, networkConfigAllEBPFDataplaneFunc,
+			false, false, false, defaultMtu, true, true, string(poolVXlan),
+			func() string { return string(*networkConfigAll.IPv4.Mode) }, func() *string { return networkConfigAll.IPv4.AutoDetectionMethod },
+			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR}),
+		Entry("should correctly compute all of the calico chart values with overlay disabled",
+			networkConfigOverlayDisabledFunc, networkConfigOverlayDisabledFunc,
+			true, true, false, defaultMtu, false, false, string(poolIPIP),
+			func() string { return string(*networkConfigOverlayDisabled.IPv4.Mode) }, func() *string { return networkConfigOverlayDisabled.IPv4.AutoDetectionMethod },
+			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR, "overlayEnabled": "false", "snatToUpstreamDNSEnabled": "true"}),
+		Entry("should correctly compute all of the calico chart values with overlay disabled, but no node cidr",
+			networkConfigOverlayDisabledFunc, networkConfigOverlayDisabledFunc,
+			true, true, false, defaultMtu, false, false, string(poolIPIP),
+			func() string { return string(*networkConfigOverlayDisabled.IPv4.Mode) }, func() *string { return networkConfigOverlayDisabled.IPv4.AutoDetectionMethod },
+			func() *string { return nil }, map[string]string{"overlayEnabled": "false", "snatToUpstreamDNSEnabled": "true"}),
+		Entry("should respect deprecated fields in order to keep backwards compatibility",
+			networkConfigDeprecatedFunc, networkConfigDeprecatedFunc,
+			true, true, false, defaultMtu, true, false, string(poolIPIP),
+			func() string { return string(*networkConfigDeprecated.IPIP) }, func() *string { return networkConfigDeprecated.IPAutoDetectionMethod },
+			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR}),
+	)
+
 	Describe("#ComputeCalicoChartValues", func() {
-		It("empty network config should properly render calico chart values", func() {
-			values, err := charts.ComputeCalicoChartValues(network, networkConfigNil, kubernetesVersion, false, true, true, false, string(nodeCIDR))
-			Expect(err).To(BeNil())
-			Expect(values).To(Equal(map[string]interface{}{
-				"images": map[string]interface{}{
-					"calico-cni":              imagevector.CalicoCNIImage(kubernetesVersion),
-					"calico-typha":            imagevector.CalicoTyphaImage(kubernetesVersion),
-					"calico-kube-controllers": imagevector.CalicoKubeControllersImage(kubernetesVersion),
-					"calico-node":             imagevector.CalicoNodeImage(kubernetesVersion),
-					"calico-podtodaemon-flex": imagevector.CalicoFlexVolumeDriverImage(kubernetesVersion),
-					"calico-cpa":              imagevector.ClusterProportionalAutoscalerImage(kubernetesVersion),
-					"calico-cpva":             imagevector.ClusterProportionalVerticalAutoscalerImage(kubernetesVersion),
-				},
-				"global": map[string]string{
-					"podCIDR":  network.Spec.PodCIDR,
-					"nodeCIDR": string(nodeCIDR),
-				},
-				"vpa": map[string]interface{}{
-					"enabled": false,
-				},
-				"config": map[string]interface{}{
-					"backend": string(calicov1alpha1.Bird),
-					"ipam": map[string]interface{}{
-						"type":   "host-local",
-						"subnet": "usePodCidr",
-					},
-					"typha": map[string]interface{}{
-						"enabled": trueVar,
-					},
-					"kubeControllers": map[string]interface{}{
-						"enabled": trueVar,
-					},
-					"veth_mtu": defaultMtu,
-					"monitoring": map[string]interface{}{
-						"enabled":          true,
-						"typhaMetricsPort": "9093",
-						"felixMetricsPort": "9091",
-					},
-					"nonPrivileged": false,
-					"felix": map[string]interface{}{
-						"ipinip": map[string]interface{}{
-							"enabled": true,
-						},
-						"bpf": map[string]interface{}{
-							"enabled": false,
-						},
-						"bpfKubeProxyIPTablesCleanup": map[string]interface{}{
-							"enabled": false,
-						},
-					},
-					"ipv4": map[string]interface{}{
-						"pool":                string(poolIPIP),
-						"mode":                string(always),
-						"autoDetectionMethod": nil,
-					},
-				},
-				"pspDisabled": true,
-			}))
+		DescribeTable("should correctly compute calico chart values with non-privileged mode enabled",
+			func(config func() *calicov1alpha1.NetworkConfig, expectedResult bool) {
+				values, err := charts.ComputeCalicoChartValues(network, config(), kubernetesVersion, true, true, false, true, &nodeCIDR)
+				Expect(err).To(BeNil())
 
-		})
+				actual, err := utils.GetFromValuesMap(values, "config", "nonPrivileged")
+				fmt.Printf("actual: %+v\n", values)
+				Expect(err).To(BeNil())
+				Expect(actual).To(Equal(expectedResult))
+			},
 
-		It("should disable felix ip in ip and set pool mode to never when setting backend to none", func() {
-			values, err := charts.ComputeCalicoChartValues(network, networkConfigBackendNone, kubernetesVersion, false, true, false, false, string(nodeCIDR))
-			Expect(err).To(BeNil())
-			Expect(values).To(Equal(map[string]interface{}{
-				"images": map[string]interface{}{
-					"calico-cni":              imagevector.CalicoCNIImage(kubernetesVersion),
-					"calico-typha":            imagevector.CalicoTyphaImage(kubernetesVersion),
-					"calico-kube-controllers": imagevector.CalicoKubeControllersImage(kubernetesVersion),
-					"calico-node":             imagevector.CalicoNodeImage(kubernetesVersion),
-					"calico-podtodaemon-flex": imagevector.CalicoFlexVolumeDriverImage(kubernetesVersion),
-					"calico-cpa":              imagevector.ClusterProportionalAutoscalerImage(kubernetesVersion),
-					"calico-cpva":             imagevector.ClusterProportionalVerticalAutoscalerImage(kubernetesVersion),
-				},
-				"global": map[string]string{
-					"podCIDR":  network.Spec.PodCIDR,
-					"nodeCIDR": string(nodeCIDR),
-				},
-				"vpa": map[string]interface{}{
-					"enabled": false,
-				},
-				"config": map[string]interface{}{
-					"backend": string(*networkConfigBackendNone.Backend),
-					"ipam": map[string]interface{}{
-						"type":   networkConfigBackendNone.IPAM.Type,
-						"subnet": string(*networkConfigBackendNone.IPAM.CIDR),
-					},
-					"typha": map[string]interface{}{
-						"enabled": trueVar,
-					},
-					"kubeControllers": map[string]interface{}{
-						"enabled": falseVar,
-					},
-					"veth_mtu": defaultMtu,
-					"monitoring": map[string]interface{}{
-						"enabled":          true,
-						"typhaMetricsPort": "9093",
-						"felixMetricsPort": "9091",
-					},
-					"nonPrivileged": false,
-					"felix": map[string]interface{}{
-						"ipinip": map[string]interface{}{
-							"enabled": false,
-						},
-						"bpf": map[string]interface{}{
-							"enabled": false,
-						},
-						"bpfKubeProxyIPTablesCleanup": map[string]interface{}{
-							"enabled": false,
-						},
-					},
-					"ipv4": map[string]interface{}{
-						"pool":                string(poolIPIP),
-						"mode":                string(never),
-						"autoDetectionMethod": nil,
-					},
-				},
-				"pspDisabled": false,
-			}))
-		})
-
-		It("should correctly compute all of the calico chart values", func() {
-			values, err := charts.ComputeCalicoChartValues(network, networkConfigAll, kubernetesVersion, true, true, false, false, string(nodeCIDR))
-			Expect(err).To(BeNil())
-			Expect(values).To(Equal(map[string]interface{}{
-				"images": map[string]interface{}{
-					"calico-cni":              imagevector.CalicoCNIImage(kubernetesVersion),
-					"calico-typha":            imagevector.CalicoTyphaImage(kubernetesVersion),
-					"calico-kube-controllers": imagevector.CalicoKubeControllersImage(kubernetesVersion),
-					"calico-node":             imagevector.CalicoNodeImage(kubernetesVersion),
-					"calico-podtodaemon-flex": imagevector.CalicoFlexVolumeDriverImage(kubernetesVersion),
-					"calico-cpa":              imagevector.ClusterProportionalAutoscalerImage(kubernetesVersion),
-					"calico-cpva":             imagevector.ClusterProportionalVerticalAutoscalerImage(kubernetesVersion),
-				},
-				"global": map[string]string{
-					"podCIDR":  network.Spec.PodCIDR,
-					"nodeCIDR": string(nodeCIDR),
-				},
-				"vpa": map[string]interface{}{
-					"enabled": true,
-				},
-				"config": map[string]interface{}{
-					"backend": string(*networkConfigAll.Backend),
-					"ipam": map[string]interface{}{
-						"type":   networkConfigAll.IPAM.Type,
-						"subnet": string(*networkConfigAll.IPAM.CIDR),
-					},
-					"typha": map[string]interface{}{
-						"enabled": trueVar,
-					},
-					"kubeControllers": map[string]interface{}{
-						"enabled": trueVar,
-					},
-					"veth_mtu": defaultMtu,
-					"monitoring": map[string]interface{}{
-						"enabled":          true,
-						"typhaMetricsPort": "9093",
-						"felixMetricsPort": "9091",
-					},
-					"nonPrivileged": false,
-					"felix": map[string]interface{}{
-						"ipinip": map[string]interface{}{
-							"enabled": true,
-						},
-						"bpf": map[string]interface{}{
-							"enabled": false,
-						},
-						"bpfKubeProxyIPTablesCleanup": map[string]interface{}{
-							"enabled": false,
-						},
-					},
-					"ipv4": map[string]interface{}{
-						"pool":                string(poolVXlan),
-						"mode":                string(*networkConfigAll.IPv4.Mode),
-						"autoDetectionMethod": *networkConfigAll.IPv4.AutoDetectionMethod,
-					},
-				},
-				"pspDisabled": false,
-			}))
-		})
-
-		It("should correctly compute all of the calico chart values with mtu", func() {
-			values, err := charts.ComputeCalicoChartValues(network, networkConfigAllMTU, kubernetesVersion, false, true, false, false, string(nodeCIDR))
-			Expect(err).To(BeNil())
-			Expect(values).To(Equal(map[string]interface{}{
-				"images": map[string]interface{}{
-					"calico-cni":              imagevector.CalicoCNIImage(kubernetesVersion),
-					"calico-typha":            imagevector.CalicoTyphaImage(kubernetesVersion),
-					"calico-kube-controllers": imagevector.CalicoKubeControllersImage(kubernetesVersion),
-					"calico-node":             imagevector.CalicoNodeImage(kubernetesVersion),
-					"calico-podtodaemon-flex": imagevector.CalicoFlexVolumeDriverImage(kubernetesVersion),
-					"calico-cpa":              imagevector.ClusterProportionalAutoscalerImage(kubernetesVersion),
-					"calico-cpva":             imagevector.ClusterProportionalVerticalAutoscalerImage(kubernetesVersion),
-				},
-				"global": map[string]string{
-					"podCIDR":  network.Spec.PodCIDR,
-					"nodeCIDR": string(nodeCIDR),
-				},
-				"vpa": map[string]interface{}{
-					"enabled": false,
-				},
-				"config": map[string]interface{}{
-					"backend": string(*networkConfigAll.Backend),
-					"ipam": map[string]interface{}{
-						"type":   networkConfigAll.IPAM.Type,
-						"subnet": string(*networkConfigAll.IPAM.CIDR),
-					},
-					"typha": map[string]interface{}{
-						"enabled": trueVar,
-					},
-					"kubeControllers": map[string]interface{}{
-						"enabled": trueVar,
-					},
-					"veth_mtu": mtuVar,
-					"monitoring": map[string]interface{}{
-						"enabled":          true,
-						"typhaMetricsPort": "9093",
-						"felixMetricsPort": "9091",
-					},
-					"nonPrivileged": false,
-					"felix": map[string]interface{}{
-						"ipinip": map[string]interface{}{
-							"enabled": true,
-						},
-						"bpf": map[string]interface{}{
-							"enabled": false,
-						},
-						"bpfKubeProxyIPTablesCleanup": map[string]interface{}{
-							"enabled": false,
-						},
-					},
-					"ipv4": map[string]interface{}{
-						"pool":                string(poolVXlan),
-						"mode":                string(*networkConfigAll.IPv4.Mode),
-						"autoDetectionMethod": *networkConfigAll.IPv4.AutoDetectionMethod,
-					},
-				},
-				"pspDisabled": false,
-			}))
-		})
-
-		It("should correctly compute all of the calico chart values with ebpf dataplane enabled and kube-proxy disabled", func() {
-			values, err := charts.ComputeCalicoChartValues(network, networkConfigAllEBPFDataplane, kubernetesVersion, false, false, false, false, string(nodeCIDR))
-			Expect(err).To(BeNil())
-			Expect(values).To(Equal(map[string]interface{}{
-				"images": map[string]interface{}{
-					"calico-cni":              imagevector.CalicoCNIImage(kubernetesVersion),
-					"calico-typha":            imagevector.CalicoTyphaImage(kubernetesVersion),
-					"calico-kube-controllers": imagevector.CalicoKubeControllersImage(kubernetesVersion),
-					"calico-node":             imagevector.CalicoNodeImage(kubernetesVersion),
-					"calico-podtodaemon-flex": imagevector.CalicoFlexVolumeDriverImage(kubernetesVersion),
-					"calico-cpa":              imagevector.ClusterProportionalAutoscalerImage(kubernetesVersion),
-					"calico-cpva":             imagevector.ClusterProportionalVerticalAutoscalerImage(kubernetesVersion),
-				},
-				"global": map[string]string{
-					"podCIDR":  network.Spec.PodCIDR,
-					"nodeCIDR": string(nodeCIDR),
-				},
-				"vpa": map[string]interface{}{
-					"enabled": false,
-				},
-				"config": map[string]interface{}{
-					"backend": string(*networkConfigAll.Backend),
-					"ipam": map[string]interface{}{
-						"type":   networkConfigAll.IPAM.Type,
-						"subnet": string(*networkConfigAll.IPAM.CIDR),
-					},
-					"typha": map[string]interface{}{
-						"enabled": trueVar,
-					},
-					"kubeControllers": map[string]interface{}{
-						"enabled": trueVar,
-					},
-					"veth_mtu": defaultMtu,
-					"monitoring": map[string]interface{}{
-						"enabled":          true,
-						"typhaMetricsPort": "9093",
-						"felixMetricsPort": "9091",
-					},
-					"nonPrivileged": false,
-					"felix": map[string]interface{}{
-						"ipinip": map[string]interface{}{
-							"enabled": true,
-						},
-						"bpf": map[string]interface{}{
-							"enabled": true,
-						},
-						"bpfKubeProxyIPTablesCleanup": map[string]interface{}{
-							"enabled": true,
-						},
-					},
-					"ipv4": map[string]interface{}{
-						"pool":                string(poolVXlan),
-						"mode":                string(*networkConfigAll.IPv4.Mode),
-						"autoDetectionMethod": *networkConfigAll.IPv4.AutoDetectionMethod,
-					},
-				},
-				"pspDisabled": false,
-			}))
-		})
-
-		It("should correctly compute all of the calico chart values with overlay disabled", func() {
-			values, err := charts.ComputeCalicoChartValues(network, networkConfigOverlayDisabled, kubernetesVersion, true, true, false, false, string(nodeCIDR))
-			Expect(err).To(BeNil())
-			Expect(values).To(Equal(map[string]interface{}{
-				"images": map[string]interface{}{
-					"calico-cni":              imagevector.CalicoCNIImage(kubernetesVersion),
-					"calico-typha":            imagevector.CalicoTyphaImage(kubernetesVersion),
-					"calico-kube-controllers": imagevector.CalicoKubeControllersImage(kubernetesVersion),
-					"calico-node":             imagevector.CalicoNodeImage(kubernetesVersion),
-					"calico-podtodaemon-flex": imagevector.CalicoFlexVolumeDriverImage(kubernetesVersion),
-					"calico-cpa":              imagevector.ClusterProportionalAutoscalerImage(kubernetesVersion),
-					"calico-cpva":             imagevector.ClusterProportionalVerticalAutoscalerImage(kubernetesVersion),
-				},
-				"global": map[string]string{
-					"podCIDR":                  network.Spec.PodCIDR,
-					"nodeCIDR":                 string(nodeCIDR),
-					"overlayEnabled":           "false",
-					"snatToUpstreamDNSEnabled": "true",
-				},
-				"vpa": map[string]interface{}{
-					"enabled": true,
-				},
-				"config": map[string]interface{}{
-					"backend": string(backendNone),
-					"ipam": map[string]interface{}{
-						"type":   networkConfigOverlayDisabled.IPAM.Type,
-						"subnet": string(*networkConfigOverlayDisabled.IPAM.CIDR),
-					},
-					"typha": map[string]interface{}{
-						"enabled": trueVar,
-					},
-					"kubeControllers": map[string]interface{}{
-						"enabled": falseVar,
-					},
-					"veth_mtu": defaultMtu,
-					"monitoring": map[string]interface{}{
-						"enabled":          true,
-						"typhaMetricsPort": "9093",
-						"felixMetricsPort": "9091",
-					},
-					"nonPrivileged": false,
-					"felix": map[string]interface{}{
-						"ipinip": map[string]interface{}{
-							"enabled": false,
-						},
-						"bpf": map[string]interface{}{
-							"enabled": false,
-						},
-						"bpfKubeProxyIPTablesCleanup": map[string]interface{}{
-							"enabled": false,
-						},
-					},
-					"ipv4": map[string]interface{}{
-						"pool":                string(calicov1alpha1.PoolIPIP),
-						"mode":                string(*networkConfigOverlayDisabled.IPv4.Mode),
-						"autoDetectionMethod": *networkConfigOverlayDisabled.IPv4.AutoDetectionMethod,
-					},
-				},
-				"pspDisabled": false,
-			}))
-		})
-
-		It("should respect deprecated fields in order to keep backwards compatibility", func() {
-			values, err := charts.ComputeCalicoChartValues(network, networkConfigDeprecated, kubernetesVersion, true, true, false, false, string(nodeCIDR))
-			Expect(err).To(BeNil())
-			Expect(values).To(Equal(map[string]interface{}{
-				"images": map[string]interface{}{
-					"calico-cni":              imagevector.CalicoCNIImage(kubernetesVersion),
-					"calico-typha":            imagevector.CalicoTyphaImage(kubernetesVersion),
-					"calico-kube-controllers": imagevector.CalicoKubeControllersImage(kubernetesVersion),
-					"calico-node":             imagevector.CalicoNodeImage(kubernetesVersion),
-					"calico-podtodaemon-flex": imagevector.CalicoFlexVolumeDriverImage(kubernetesVersion),
-					"calico-cpa":              imagevector.ClusterProportionalAutoscalerImage(kubernetesVersion),
-					"calico-cpva":             imagevector.ClusterProportionalVerticalAutoscalerImage(kubernetesVersion),
-				},
-				"global": map[string]string{
-					"podCIDR":  network.Spec.PodCIDR,
-					"nodeCIDR": string(nodeCIDR),
-				},
-				"vpa": map[string]interface{}{
-					"enabled": true,
-				},
-				"config": map[string]interface{}{
-					"backend": string(*networkConfigDeprecated.Backend),
-					"ipam": map[string]interface{}{
-						"type":   networkConfigDeprecated.IPAM.Type,
-						"subnet": string(*networkConfigDeprecated.IPAM.CIDR),
-					},
-					"typha": map[string]interface{}{
-						"enabled": trueVar,
-					},
-					"kubeControllers": map[string]interface{}{
-						"enabled": trueVar,
-					},
-					"veth_mtu": defaultMtu,
-					"monitoring": map[string]interface{}{
-						"enabled":          true,
-						"typhaMetricsPort": "9093",
-						"felixMetricsPort": "9091",
-					},
-					"nonPrivileged": false,
-					"felix": map[string]interface{}{
-						"ipinip": map[string]interface{}{
-							"enabled": true,
-						},
-						"bpf": map[string]interface{}{
-							"enabled": false,
-						},
-						"bpfKubeProxyIPTablesCleanup": map[string]interface{}{
-							"enabled": false,
-						},
-					},
-					"ipv4": map[string]interface{}{
-						"pool":                string(calicov1alpha1.PoolIPIP),
-						"mode":                string(*networkConfigDeprecated.IPIP),
-						"autoDetectionMethod": *networkConfigDeprecated.IPAutoDetectionMethod,
-					},
-				},
-				"pspDisabled": false,
-			}))
-		})
-
-		It("should correctly compute calico chart values when non-privileged mode is enabled", func() {
-			values, err := charts.ComputeCalicoChartValues(network, networkConfigAll, kubernetesVersion, true, true, false, true, string(nodeCIDR))
-			Expect(err).To(BeNil())
-
-			actual, err := utils.GetFromValuesMap(values, "config", "nonPrivileged")
-			Expect(err).To(BeNil())
-			Expect(actual).To(BeTrue())
-		})
-
-		It("should correctly compute calico chart values when non-privileged mode and ebpf dataplane are enabled", func() {
-			values, err := charts.ComputeCalicoChartValues(network, networkConfigAllEBPFDataplane, kubernetesVersion, true, true, false, true, string(nodeCIDR))
-			Expect(err).To(BeNil())
-
-			actual, err := utils.GetFromValuesMap(values, "config", "nonPrivileged")
-			Expect(err).To(BeNil())
-			Expect(actual).To(BeFalse())
-		})
+			Entry("default", networkConfigAllFunc, true),
+			Entry("ebpf dataplane enabled", networkConfigAllEBPFDataplaneFunc, false),
+		)
 
 		It("should error on invalid config value", func() {
-			_, err := charts.ComputeCalicoChartValues(network, networkConfigInvalid, kubernetesVersion, true, true, false, false, string(nodeCIDR))
+			_, err := charts.ComputeCalicoChartValues(network, networkConfigInvalid, kubernetesVersion, true, true, false, false, &nodeCIDR)
 			Expect(err).To(Equal(fmt.Errorf("error when generating calico config: unsupported value for backend: invalid")))
 		})
 	})
@@ -627,16 +334,22 @@ var _ = Describe("Chart package test", func() {
 				return manifest.Manifest{Name: fmt.Sprintf("test/templates/%s", name), Content: testManifestContent}
 			}
 		})
-		It("Render Calico charts correctly", func() {
-			mockChartRenderer.EXPECT().Render(calico.CalicoChartPath, calico.ReleaseName, metav1.NamespaceSystem, gomock.Any()).Return(&chartrenderer.RenderedChart{
-				ChartName: "test",
-				Manifests: []manifest.Manifest{
-					mkManifest(charts.CalicoConfigKey),
-				},
-			}, nil)
+		DescribeTable("Render Calico charts correctly",
+			func(nodes *string) {
+				mockChartRenderer.EXPECT().Render(calico.CalicoChartPath, calico.ReleaseName, metav1.NamespaceSystem, gomock.Any()).Return(&chartrenderer.RenderedChart{
+					ChartName: "test",
+					Manifests: []manifest.Manifest{
+						mkManifest(charts.CalicoConfigKey),
+					},
+				}, nil)
 
-			_, err := charts.RenderCalicoChart(mockChartRenderer, network, networkConfigNil, kubernetesVersion, false, true, false, false, string(nodeCIDR))
-			Expect(err).NotTo(HaveOccurred())
-		})
+				_, err := charts.RenderCalicoChart(mockChartRenderer, network, networkConfigNil, kubernetesVersion, false, true, false, false, nodes)
+				Expect(err).NotTo(HaveOccurred())
+
+			},
+
+			Entry("with node cidr", &nodeCIDR),
+			Entry("without node cidr", nil),
+		)
 	})
 })

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -151,7 +151,7 @@ func ComputeCalicoChartValues(
 	kubeProxyEnabled bool,
 	isPSPDisabled bool,
 	nonPrivileged bool,
-	nodeCIDR string,
+	nodeCIDR *string,
 ) (map[string]interface{}, error) {
 	typedConfig, err := generateChartValues(config, kubeProxyEnabled, nonPrivileged)
 	if err != nil {
@@ -175,11 +175,14 @@ func ComputeCalicoChartValues(
 			calico.ClusterProportionalVerticalAutoscalerImageName: imagevector.ClusterProportionalVerticalAutoscalerImage(kubernetesVersion),
 		},
 		"global": map[string]string{
-			"podCIDR":  network.Spec.PodCIDR,
-			"nodeCIDR": nodeCIDR,
+			"podCIDR": network.Spec.PodCIDR,
 		},
 		"config":      calicoConfig,
 		"pspDisabled": isPSPDisabled,
+	}
+
+	if nodeCIDR != nil {
+		calicoChartValues["global"].(map[string]string)["nodeCIDR"] = *nodeCIDR
 	}
 
 	if config != nil && config.Overlay != nil {

--- a/pkg/charts/values.go
+++ b/pkg/charts/values.go
@@ -35,7 +35,7 @@ func RenderCalicoChart(
 	kubeProxyEnabled bool,
 	isPSPDisabled bool,
 	nonPrivileged bool,
-	nodeCIDR string,
+	nodeCIDR *string,
 ) ([]byte, error) {
 	values, err := ComputeCalicoChartValues(network, config, kubernetesVersion, wantsVPA, kubeProxyEnabled, isPSPDisabled, nonPrivileged, nodeCIDR)
 	if err != nil {

--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -136,7 +136,7 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, network *extens
 		kubeProxyEnabled,
 		gardencorev1beta1helper.IsPSPDisabled(cluster.Shoot),
 		features.FeatureGate.Enabled(features.NonPrivilegedCalicoNode),
-		*cluster.Shoot.Spec.Networking.Nodes,
+		cluster.Shoot.Spec.Networking.Nodes,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Allow non-specified node cidr.

The changes related to source network address translation unintentionally enforced a specified node cidr. This change relaxes the condition, i.e. node cidr is optional again.
The tests have been refactored to make it easier to add new variants without node cidr specified.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Calico extension does not crash anymore when node cidr is not specified.
```
