### PR TITLE
Switch from DockerHub to Gardener GCR

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -1,7 +1,7 @@
 images:
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
-  repository: docker.io/calico/node
+  repository: eu.gcr.io/gardener-project/3rd/projectcalico/calico
   tag: v3.25.0
   targetVersion: ">= 1.21"
   labels:
@@ -15,7 +15,7 @@ images:
       availability_requirement: 'high'
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
-  repository: docker.io/calico/node
+  repository: eu.gcr.io/gardener-project/3rd/projectcalico/calico
   tag: v3.22.2
   targetVersion: "< 1.21"
   labels:
@@ -29,7 +29,7 @@ images:
       availability_requirement: 'high'
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
-  repository: docker.io/calico/cni
+  repository: eu.gcr.io/gardener-project/3rd/calico/cni
   tag: v3.25.0
   targetVersion: ">= 1.21"
   labels:
@@ -43,7 +43,7 @@ images:
       availability_requirement: 'high'
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
-  repository: docker.io/calico/cni
+  repository: eu.gcr.io/gardener-project/3rd/calico/cni
   tag: v3.22.2
   targetVersion: "< 1.21"
   labels:
@@ -57,7 +57,7 @@ images:
       availability_requirement: 'high'
 - name: calico-typha
   sourceRepository: github.com/projectcalico/typha
-  repository: docker.io/calico/typha
+  repository: eu.gcr.io/gardener-project/3rd/calico/typha
   tag: v3.25.0
   targetVersion: ">= 1.21"
   labels:
@@ -75,7 +75,7 @@ images:
       availability_requirement: 'high'
 - name: calico-typha
   sourceRepository: github.com/projectcalico/typha
-  repository: docker.io/calico/typha
+  repository: eu.gcr.io/gardener-project/3rd/calico/typha
   tag: v3.22.2
   targetVersion: "< 1.21"
   labels:
@@ -93,7 +93,7 @@ images:
       availability_requirement: 'high'
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers
-  repository: docker.io/calico/kube-controllers
+  repository: eu.gcr.io/gardener-project/3rd/calico/kube-controllers
   tag: v3.25.0
   targetVersion: ">= 1.21"
   labels:
@@ -107,7 +107,7 @@ images:
       availability_requirement: 'low'
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers
-  repository: docker.io/calico/kube-controllers
+  repository: eu.gcr.io/gardener-project/3rd/calico/kube-controllers
   tag: v3.22.2
   targetVersion: "< 1.21"
   labels:
@@ -121,7 +121,7 @@ images:
       availability_requirement: 'low'
 - name: calico-podtodaemon-flex
   sourceRepository: github.com/projectcalico/pod2daemon
-  repository: docker.io/calico/pod2daemon-flexvol
+  repository: eu.gcr.io/gardener-project/3rd/calico/pod2daemon-flexvol
   tag: v3.22.2
   # targetVersion is removed to avoid a panic in imagevector.findImage function.
   # targetVersion: "< 1.21"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
This PR is needed to support IPv6 single stack and avoid DockerHub pull limits as it uses copied images from Gardener GCR instead.
Part of #619

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
