### PR TITLE
Fixes typos and nits in docs/shoot_overlay_network.md

### DIFF
--- a/docs/shoot_overlay_network.md
+++ b/docs/shoot_overlay_network.md
@@ -1,5 +1,5 @@
 # Enable / disable overlay network for shoots with Calico
-Gardener can be used with or without the overlay network. 
+Gardener can be used with or without the overlay network.
 
 Starting versions:
 - [provider-gcp@v1.25.0](https://github.com/gardener/gardener-extension-provider-gcp/releases/tag/v1.25.0)
@@ -16,21 +16,21 @@ This is done through the encapsulation of pod packets in the node network so tha
 
 ![](./assets/Overlay-Network.drawio.png)
 
-In order to simplify the troubleshooting of problems and reducing the latency of packets travelling between nodes, the overlay network is disabled by default for extension default as stated above for all new clusters.
+In order to simplify the troubleshooting of problems and reduce the latency of packets traveling between nodes, the overlay network is disabled by default as stated above for all new clusters.
 
 ![](./assets/No-Overlay-Network.drawio.png)
 
-This means that the routing is done directly through the VPC routing table. Basically, when a new node it created, it is assigned a slice (usually a /24) of the pod network. All future pods in that node are going to be in this slice. Then, the cloud-controller-manager updated the cloud provider router to add the new route (all packets with in the network slice as destination should go to that node).
+This means that the routing is done directly through the VPC routing table. Basically, when a new node is created, it is assigned a slice (usually a /24) of the pod network. All future pods in that node are going to be in this slice. Then, the cloud-controller-manager updates the cloud provider router to add the new route (all packets within the network slice as destination should go to that node).
 
 This has the advantage of:
 - Doing less work for the node as encapsulation takes some CPU cycles.
 - The maximum transmission unit (MTU) is slightly bigger resulting in slightly better performance, i.e. potentially more workload bytes per packet.
 - More direct and simpler setup, which makes the problems much easier to troubleshoot.
 
-## Enabling the overlay network
-In certain cases, the overlay network might be preferable if, for example, the customer wants to create multiple clusters in the same VPC without ensuring there's no overlap between the pod networks. 
+**In the case where multiple shoots are in the same VPC and the overlay network is disabled, if the pod's network is not configured properly, there is a very strong chance that some pod IP address might overlap, which is going to cause all sorts of funny problems.** So, if someone asks you how to avoid that, they need to make sure that the podCIDRs for each shoot **do not overlap with each other**.
 
-**In that case (multiple shoot in the same VPC), if the pod's network is not configured properly, there is a very strong chance that some pod IP address might overlap, which is going to cause all sorts of funny problems.** So, if someone asks you how to avoid that, they need to make sure that the podCIDR for each shoot **do not overlap with each other**.
+## Enabling the overlay network
+In certain cases, the overlay network might be preferable if, for example, the customer wants to create multiple clusters in the same VPC without ensuring there's no overlap between the pod networks.
 
 To enable the overlay network, add the following to the shoot's YAML:
 ```yaml
@@ -70,7 +70,7 @@ spec:
 ```
 
 ## How to know if a cluster is using overlay or not?
-You can look at any of the old nodes. If there are tunl0 devices at least at some point in time the overlay network was used.
+You can look at any of the old nodes. If there are `tunl0` devices at least at some point in time the overlay network was used.
 Another way is to look into the Network object in the shoot's control plane namespace on the seed (see example above).
 
 ## Do we have some documentation somewhere on how to do the migration?


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking documentation
/kind task

**What this PR does / why we need it**:
Fixes some typos in the [`docs/shoot_overlay_network.md`]() file and moves the paragraph about the dangers when the pod CIDRs overlap when multiple shoots share the same VPC, so that it is a bit more clear.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
