### PR TITLE
Export artifacts analogous to gardener/gardener in end-to-end tests

### DIFF
--- a/hack/test-e2e-provider-local.sh
+++ b/hack/test-e2e-provider-local.sh
@@ -16,9 +16,11 @@ fi
 
 cd "$repo_root/gardener"
 git checkout 1f94c1e5b4b9e7cdf40d2e314dc74fea54a0d293 # g/g v1.67.1
+source "$repo_root/gardener/hack/ci-common.sh"
 make kind-up
 trap '{
   cd "$repo_root/gardener"
+  export_artifacts "gardener-local"
   make kind-down
 }' EXIT
 export KUBECONFIG=$repo_root/gardener/example/gardener-local/kind/local/kubeconfig


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind test

**What this PR does / why we need it**:
Export artifacts analogous to gardener/gardener in end-to-end tests.

This should provide more data from the end-to-end cluster for error analysis.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
