### PR TITLE
topology-aware routing: Adapt to the upstream annotation change in K8s 1.27

### DIFF
--- a/charts/gardener-extension-admission-calico/charts/runtime/templates/service.yaml
+++ b/charts/gardener-extension-admission-calico/charts/runtime/templates/service.yaml
@@ -5,9 +5,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports: '[{"protocol":"TCP","port":{{ .Values.global.webhookConfig.serverPort }}}]'
-  {{- if .Values.global.service.topologyAwareRouting.enabled }}
+    {{- if .Values.global.service.topologyAwareRouting.enabled }}
+    {{- if semverCompare ">= 1.27-0" .Capabilities.KubeVersion.GitVersion }}
+    service.kubernetes.io/topology-mode: "auto"
+    {{- else }}
     service.kubernetes.io/topology-aware-hints: "auto"
-  {{- end }}
+    {{- end }}
+    {{- end }}
   labels:
 {{ include "labels" . | indent 4 }}
     {{- if .Values.global.service.topologyAwareRouting.enabled }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/area networking
/kind enhancement

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/pull/7933

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
