### PR TITLE
Switch the calico images to be pulled from quay.io

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -1,7 +1,7 @@
 images:
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
-  repository: eu.gcr.io/gardener-project/3rd/calico/node
+  repository: quay.io/calico/node
   tag: v3.25.1
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -14,7 +14,7 @@ images:
       availability_requirement: 'high'
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
-  repository: eu.gcr.io/gardener-project/3rd/calico/cni
+  repository: quay.io/calico/cni
   tag: v3.25.1
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -27,7 +27,7 @@ images:
       availability_requirement: 'high'
 - name: calico-typha
   sourceRepository: github.com/projectcalico/typha
-  repository: eu.gcr.io/gardener-project/3rd/calico/typha
+  repository: quay.io/calico/typha
   tag: v3.25.1
   labels:
   - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
@@ -44,7 +44,7 @@ images:
       availability_requirement: 'high'
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers
-  repository: eu.gcr.io/gardener-project/3rd/calico/kube-controllers
+  repository: quay.io/calico/kube-controllers
   tag: v3.25.1
   labels:
   - name: 'gardener.cloud/cve-categorisation'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
See https://github.com/gardener/gardener-extension-networking-calico/issues/274

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-networking-calico/issues/274

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
networking-calico does no longer use Gardener GCR copies for the calico images. Instead, the upstream quay.io container images are used (`quay.io/calico/node`, `quay.io/calico/cni`, `quay.io/calico/typha`, `quay.io/calico/kube-controllers`).
```
