### PR TITLE
Fix selector of cluster-proportional autoscalers for calico-typha.

### DIFF
--- a/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpha/deployment-calico-typha-horizontal-autoscaler.yaml
@@ -3,16 +3,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
   name: calico-typha-horizontal-autoscaler
   namespace: kube-system
   labels:
-    k8s-app: calico-typha-autoscaler
+    k8s-app: calico-typha-horizontal-autoscaler
 spec:
   revisionHistoryLimit: 5
   replicas: 1
   selector:
     matchLabels:
-      k8s-app: calico-typha-autoscaler
+      k8s-app: calico-typha-horizontal-autoscaler
   template:
     metadata:
       annotations:
@@ -22,7 +24,7 @@ spec:
         networking.gardener.cloud/to-apiserver: allowed
         networking.gardener.cloud/to-dns: allowed
         origin: gardener
-        k8s-app: calico-typha-autoscaler
+        k8s-app: calico-typha-horizontal-autoscaler
     spec:
       priorityClassName: gardener-shoot-system-800
       # Make sure to not use the coredns for DNS resolution.

--- a/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
+++ b/charts/internal/calico/templates/typha-cpva/deployment-calico-typha-vertical-autoscaler.yaml
@@ -3,16 +3,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
   name: calico-typha-vertical-autoscaler
   namespace: kube-system
   labels:
-    k8s-app: calico-typha-autoscaler
+    k8s-app: calico-typha-vertical-autoscaler
 spec:
   revisionHistoryLimit: 5
   replicas: 1
   selector:
     matchLabels:
-      k8s-app: calico-typha-autoscaler
+      k8s-app: calico-typha-vertical-autoscaler
   template:
     metadata:
       annotations:
@@ -22,7 +24,7 @@ spec:
         networking.gardener.cloud/to-apiserver: allowed
         networking.gardener.cloud/to-dns: allowed
         origin: gardener
-        k8s-app: calico-typha-autoscaler
+        k8s-app: calico-typha-vertical-autoscaler
     spec:
       priorityClassName: gardener-shoot-system-800
       # Make sure to not use the coredns for DNS resolution.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Fix selector of cluster-proportional autoscalers for calico-typha.

Both, the vertical as well as the horizontal autoscalers used the same label. This causes issues when other controllers try to validate the the correct amount of pods are running as both vertical as well as horizontal autoscalers match the label selector.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Vertical and horizontal cluster-proportional autoscalers for calico-typha now use different label selectors.
```
