### PR TITLE
update calico to v3.26.3

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
   repository: quay.io/calico/node
-  tag: v3.26.2
+  tag: v3.26.3
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -15,7 +15,7 @@ images:
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
   repository: quay.io/calico/cni
-  tag: v3.26.2
+  tag: v3.26.3
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -28,7 +28,7 @@ images:
 - name: calico-typha
   sourceRepository: github.com/projectcalico/typha
   repository: quay.io/calico/typha
-  tag: v3.26.2
+  tag: v3.26.3
   labels:
   - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
     value:
@@ -45,7 +45,7 @@ images:
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers
   repository: quay.io/calico/kube-controllers
-  tag: v3.26.2
+  tag: v3.26.3
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Update calico to `v3.26.3`. As v3.26.2`shouldn't be used, see https://github.com/projectcalico/calico/blob/v3.26.3/release-notes/v3.26.3-release-notes.md.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update calico to `v3.26.3`.
```
