### PR TITLE
Determine iptables backend in container add-snat-rule-to-upstream-dns.

### DIFF
--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -173,16 +173,12 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
-          volumeMounts:
-            - mountPath: /run/xtables.lock
-              name: xtables-lock
-              readOnly: false
           command:
           - /bin/sh
           - -c
           - |
-            nft_kubelet_rules=$( (iptables-nft-save -t mangle || true; ip6tables-nft-save -t mangle || true) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)');
-            if [[ $nft_kubelet_rules != "" ]]; then
+            nft_kubelet_rules=$( (iptables-nft-save -t mangle; ip6tables-nft-save -t mangle ) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)')
+            if [ -n "$nft_kubelet_rules" ]; then
               backend="nft"
             else 
               backend="legacy"
@@ -195,7 +191,10 @@ spec:
               done
               sleep 60
             done
-
+          volumeMounts:
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
         {{- end }}
         - name: calico-node
           image: {{ index .Values.images "calico-node" }}

--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -173,10 +173,29 @@ spec:
             requests:
               cpu: 10m
               memory: 50Mi
+          volumeMounts:
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
           command:
           - /bin/sh
           - -c
-          - "while true; do sleep 15; for i in $(cat /etc/resolv.conf | grep nameserver | sed -n -e 's/^.*nameserver //p' ); do iptables -t nat -C POSTROUTING -s ${POD_CIDR} -d $i/32 ! -o cali+ -m comment --comment \"calico masquerade non-cluster\" -j MASQUERADE 2>/dev/null || iptables -t nat -I POSTROUTING 1 -s ${POD_CIDR} -d $i/32 ! -o cali+ -m comment --comment \"calico masquerade non-cluster\" -j MASQUERADE; done; sleep 45; done"
+          - |
+            nft_kubelet_rules=$( (iptables-nft-save -t mangle || true; ip6tables-nft-save -t mangle || true) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)');
+            if [[ $nft_kubelet_rules != "" ]]; then
+              backend="nft"
+            else 
+              backend="legacy"
+            fi
+            sleep 15
+            while true; do
+              for i in $(cat /etc/resolv.conf | grep nameserver | sed -n -e 's/^.*nameserver //p' ); do
+                iptables-$backend -t nat -C POSTROUTING -s ${POD_CIDR} -d $i/32 ! -o cali+ -m comment --comment "calico masquerade non-cluster" -j MASQUERADE 2>/dev/null \
+                || iptables-$backend -t nat -I POSTROUTING 1 -s ${POD_CIDR} -d $i/32 ! -o cali+ -m comment --comment "calico masquerade non-cluster" -j MASQUERADE
+              done
+              sleep 60
+            done
+
         {{- end }}
         - name: calico-node
           image: {{ index .Values.images "calico-node" }}


### PR DESCRIPTION
The calico-node container determines the backend of iptables in the calico-node executable based on existing chains in the mangle table. The container `add-snat-rule-to-upstream-dns` adds additional rules to masquerade traffic to the upstream DNS server. These rules must added with the same iptables version as used by calico-node. For that reason this PR adds a iptables-backend detection to this container.

In addition to that, we mount the xtables lock file into `add-snat-rule-to-upstream-dns`. 

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Determine iptables backend in container add-snat-rule-to-upstream-dns.
```
