### PR TITLE
Revert "Update calico images to v3.27.2 (patch)"

### DIFF
--- a/charts/internal/calico/templates/custom-resource-definition/crd-felixconfigurations.yaml
+++ b/charts/internal/calico/templates/custom-resource-definition/crd-felixconfigurations.yaml
@@ -121,13 +121,6 @@ spec:
                   Loose]'
                 pattern: ^(?i)(Disabled|Strict|Loose)?$
                 type: string
-              bpfExcludeCIDRsFromNAT:
-                description: BPFExcludeCIDRsFromNAT is a list of CIDRs that are to
-                  be excluded from NAT resolution so that host can handle them. A
-                  typical usecase is node local DNS cache.
-                items:
-                  type: string
-                type: array
               bpfExtToServiceConnmark:
                 description: 'BPFExtToServiceConnmark in BPF mode, control a 32bit
                   mark that is set on connections from an external client to a local

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
   repository: quay.io/calico/node
-  tag: v3.27.2
+  tag: v3.27.0
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -15,7 +15,7 @@ images:
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
   repository: quay.io/calico/cni
-  tag: v3.27.2
+  tag: v3.27.0
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -28,7 +28,7 @@ images:
 - name: calico-typha
   sourceRepository: github.com/projectcalico/typha
   repository: quay.io/calico/typha
-  tag: v3.27.2
+  tag: v3.27.0
   labels:
   - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
     value:
@@ -45,7 +45,7 @@ images:
 - name: calico-kube-controllers
   sourceRepository: github.com/projectcalico/kube-controllers
   repository: quay.io/calico/kube-controllers
-  tag: v3.27.2
+  tag: v3.27.0
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
Reverts gardener/gardener-extension-networking-calico#354 due to calico v3.27.2 not working on arm (see https://github.com/projectcalico/calico/issues/8541 for details).