### PR TITLE
Feature: node to node wireguard encryption

### DIFF
--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -332,6 +332,14 @@ spec:
             - name: FELIX_CHAININSERTMODE
               value: "Append"
             {{- end }}
+            {{- if .Values.config.ipv4.wireguard }}
+            - name: FELIX_WIREGUARDENABLED
+              value: "true"
+            {{- end }}
+            {{- if .Values.config.ipv6.wireguard }}
+            - name: FELIX_WIREGUARDENABLEDV6
+              value: "true"
+            {{- end }}
             # Enable automatic management of kubeconfig used by CNI (required due to limited lifetime of service account tokens, BoundServiceAccountTokenVolume feature)
             - name: CALICO_MANAGE_CNI
               value: "true"

--- a/charts/internal/calico/values.yaml
+++ b/charts/internal/calico/values.yaml
@@ -24,12 +24,14 @@ config:
     pool: ipip # or vxlan
     mode: "Always"
     autoDetectionMethod: "first-found"
+    wireguard: false
   ipv6:
     enabled: false
     pool: vxlan
     mode: "Never"
     autoDetectionMethod: "first-found"
     natOutgoing: true
+    wireguard: false
   felix:
     ipinip:
       enabled: "true"

--- a/hack/api-reference/calico.md
+++ b/hack/api-reference/calico.md
@@ -212,6 +212,17 @@ It was moved into the IPv4 struct, kept for backwards compatibility.
 Will be removed in a future Gardener release.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>wireguard</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>WireguardEncryption is the option to enable node to node wireguard encryption</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="calico.networking.extensions.gardener.cloud/v1alpha1.AutoScaling">AutoScaling

--- a/hack/api-reference/calico.md
+++ b/hack/api-reference/calico.md
@@ -214,7 +214,7 @@ Will be removed in a future Gardener release.</p>
 </tr>
 <tr>
 <td>
-<code>wireguard</code></br>
+<code>wireguardEncryption</code></br>
 <em>
 bool
 </em>

--- a/pkg/apis/calico/types_network.go
+++ b/pkg/apis/calico/types_network.go
@@ -100,6 +100,9 @@ type NetworkConfig struct {
 	// It was moved into the IPv4 struct, kept for backwards compatibility.
 	// Will be removed in a future Gardener release.
 	IPAutoDetectionMethod *string
+
+	// WireguardEncryption is the option to enable node to node wireguard encryption
+	WireguardEncryption bool
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/calico/v1alpha1/types_network.go
+++ b/pkg/apis/calico/v1alpha1/types_network.go
@@ -119,6 +119,9 @@ type NetworkConfig struct {
 	// Will be removed in a future Gardener release.
 	// +optional
 	IPAutoDetectionMethod *string `json:"ipAutodetectionMethod,omitempty"`
+
+	// WireguardEncryption is the option to enable node to node wireguard encryption
+	WireguardEncryption bool `json:"wireguardEncryption,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/calico/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/calico/v1alpha1/zz_generated.conversion.go
@@ -250,6 +250,7 @@ func autoConvert_v1alpha1_NetworkConfig_To_calico_NetworkConfig(in *NetworkConfi
 	out.AutoScaling = (*calico.AutoScaling)(unsafe.Pointer(in.AutoScaling))
 	out.IPIP = (*calico.PoolMode)(unsafe.Pointer(in.IPIP))
 	out.IPAutoDetectionMethod = (*string)(unsafe.Pointer(in.IPAutoDetectionMethod))
+	out.WireguardEncryption = in.WireguardEncryption
 	return nil
 }
 
@@ -271,6 +272,7 @@ func autoConvert_calico_NetworkConfig_To_v1alpha1_NetworkConfig(in *calico.Netwo
 	out.AutoScaling = (*AutoScaling)(unsafe.Pointer(in.AutoScaling))
 	out.IPIP = (*PoolMode)(unsafe.Pointer(in.IPIP))
 	out.IPAutoDetectionMethod = (*string)(unsafe.Pointer(in.IPAutoDetectionMethod))
+	out.WireguardEncryption = in.WireguardEncryption
 	return nil
 }
 

--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -248,7 +248,7 @@ var _ = Describe("Chart package test", func() {
 						"pool":                "",
 						"mode":                "",
 						"autoDetectionMethod": nil,
-						"natOutgoing":         false,
+						"natOutgoing":         configResult().WireguardEncryption,
 						"wireguard":           configResult().WireguardEncryption,
 					},
 				},

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -260,6 +260,9 @@ func mergeCalicoValuesWithConfig(c *calicoConfig, config *calicov1alpha1.Network
 
 	c.IPv4.Wireguard = config.WireguardEncryption
 	c.IPv6.Wireguard = config.WireguardEncryption
+	if config.WireguardEncryption {
+		c.IPv6.NATOutgoing = true
+	}
 
 	if config.Backend != nil {
 		switch *config.Backend {

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -61,6 +61,7 @@ type ipv4 struct {
 	Pool                calicov1alpha1.Pool     `json:"pool"`
 	Mode                calicov1alpha1.PoolMode `json:"mode"`
 	AutoDetectionMethod *string                 `json:"autoDetectionMethod"`
+	Wireguard           bool                    `json:"wireguard"`
 }
 
 type ipv6 struct {
@@ -69,6 +70,7 @@ type ipv6 struct {
 	Mode                calicov1alpha1.PoolMode `json:"mode"`
 	AutoDetectionMethod *string                 `json:"autoDetectionMethod"`
 	NATOutgoing         bool                    `json:"natOutgoing"`
+	Wireguard           bool                    `json:"wireguard"`
 }
 
 type ipam struct {
@@ -255,6 +257,9 @@ func mergeCalicoValuesWithConfig(c *calicoConfig, config *calicov1alpha1.Network
 	if config == nil {
 		return c, nil
 	}
+
+	c.IPv4.Wireguard = config.WireguardEncryption
+	c.IPv6.Wireguard = config.WireguardEncryption
 
 	if config.Backend != nil {
 		switch *config.Backend {


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Introduces the field `WireguardEncryption` to the `NetworkConfig`. This addition facilitates the configuration of Wireguard encryption on Felix, regardless of whether IPv4 or IPv6 is utilized. It enables users to incorporate Wireguard encryption when setting up the cluster, eliminating the need for manual patching in the FelixConfiguration resource.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
At the moment, it's a straightforward activation of the Felix configuration parameter: **wireguardEnabled**. This setting is retrieved from the Calico documentation: https://docs.tigera.io/calico/latest/network-policy/encrypt-cluster-pod-traffic.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
allow users to enable node to node wireguard encryption
```
