### PR TITLE
Remove unneeded kubeconfig secret from e2e tests.

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -10,13 +10,11 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/gardener/gardener-extension-networking-calico/test/templates"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/utils/access"
 	. "github.com/onsi/ginkgo/v2"
@@ -68,20 +66,7 @@ func testNetwork(ctx context.Context, f *framework.ShootCreationFramework) bool 
 	)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-	shootKubeconfigSecret := &corev1.Secret{}
-	gardenClient := f.GardenClient.Client()
-	gardenClient.Get(ctx, client.ObjectKey{Name: gardenerutils.ComputeShootProjectResourceName(f.Shoot.Name, gardenerutils.ShootProjectSecretSuffixKubeconfig)}, shootKubeconfigSecret)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
 	f.ShootFramework.ShootClient, err = access.CreateShootClientFromAdminKubeconfig(ctx, f.GardenClient, f.Shoot)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-	newShootKubeconfigSecret := &corev1.Secret{ObjectMeta: v1.ObjectMeta{
-		Name:      "kubeconfig",
-		Namespace: values.HelmDeployNamespace},
-		Data: map[string][]byte{"kubeconfig": shootKubeconfigSecret.Data["kubeconfig"]},
-	}
-	err = f.ShootFramework.ShootClient.Client().Create(ctx, newShootKubeconfigSecret)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	resourceDir, err := filepath.Abs(filepath.Join(".."))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind test

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
