### PR TITLE
Publish separate admission Helm charts

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -10,9 +10,18 @@ gardener-extension-networking-calico:
         attribute: image.repository
       - ref: ocm-resource:gardener-extension-networking-calico.tag
         attribute: image.tag
-    - &admission-calico
-      name: admission-calico
-      dir: charts/gardener-extension-admission-calico
+    - &admission-calico-application
+      name: admission-calico-application
+      dir: charts/gardener-extension-admission-calico/charts/application
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-extension-admission-calico.repository
+        attribute: global.image.repository
+      - ref: ocm-resource:gardener-extension-admission-calico.tag
+        attribute: global.image.tag
+    - &admission-calico-runtime
+      name: admission-calico-runtime
+      dir: charts/gardener-extension-admission-calico/charts/runtime
       registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
       mappings:
       - ref: ocm-resource:gardener-extension-admission-calico.repository
@@ -80,7 +89,8 @@ gardener-extension-networking-calico:
         publish:
           helmcharts:
           - *networking-calico
-          - *admission-calico
+          - *admission-calico-application
+          - *admission-calico-runtime
     pull-request:
       traits:
         pull-request: ~
@@ -89,7 +99,8 @@ gardener-extension-networking-calico:
         publish:
           helmcharts:
           - *networking-calico
-          - *admission-calico
+          - *admission-calico-application
+          - *admission-calico-runtime
     release:
       traits:
         version:
@@ -117,5 +128,7 @@ gardener-extension-networking-calico:
           helmcharts:
           - <<: *networking-calico
             registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions
-          - <<: *admission-calico
+          - <<: *admission-calico-application
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions
+          - <<: *admission-calico-runtime
             registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking delivery
/kind enhancement

**What this PR does / why we need it**:
Admission Helm charts have to be published as separate charts for application and runtime that they can be used in `operator.gardener.cloud/v1alpha1.Extension` resource.

**Which issue(s) this PR fixes**:
Follow up to #445

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
