### PR TITLE
Reset `NetworkUnavailable` condition after `calico-node` startup.

### DIFF
--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -196,6 +196,64 @@ spec:
               name: xtables-lock
               readOnly: false
         {{- end }}
+        # Ensure that the NetworkUnavailable condition is set correctly after startup
+        # There may be a race between an old instance shutting down and a new instance starting up
+        {{- if ne .Values.config.backend "none" }}
+        - name: network-unavailable-condition-ensurer
+          image: {{ index .Values.images "calico-node" }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: false
+          env:
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
+            - name: IP
+            {{- if .Values.config.ipv4.enabled }}
+              value: "autodetect"
+            {{- else }}
+              value: "none"
+            {{- end }}
+            {{- if .Values.config.ipv4.enabled }}
+            {{- if .Values.config.ipv4.autoDetectionMethod }}
+            - name: IP_AUTODETECTION_METHOD
+              value: "{{ .Values.config.ipv4.autoDetectionMethod }}"
+            {{- end }}
+            {{- end }}
+            {{- if .Values.config.ipv6.enabled }}
+            - name: IP6
+              value: "autodetect"
+            {{- if .Values.config.ipv6.autoDetectionMethod }}
+            - name: IP6_AUTODETECTION_METHOD
+              value: "{{ .Values.config.ipv6.autoDetectionMethod }}"
+            {{- end }}
+            {{- end }}
+            - name: NO_DEFAULT_POOLS
+              value: "true"
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            requests:
+              cpu: 1m
+              memory: 20Mi
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting 30s for initialization to complete..."
+              sleep 30
+              echo "Ensuring NetworkUnavailable condition is set correctly..."
+              calico-node -startup
+              echo "Finished ensuring NetworkUnavailable condition is set correctly."
+              while true; do
+                echo "Sleeping for 1h..."
+                sleep 3600
+              done
+        {{- end }}
         - name: calico-node
           image: {{ index .Values.images "calico-node" }}
           envFrom:

--- a/charts/internal/calico/templates/node/vpa.yaml
+++ b/charts/internal/calico/templates/node/vpa.yaml
@@ -27,4 +27,12 @@ spec:
         cpu: 1
         memory: 1G
       controlledValues: RequestsOnly
+    - containerName: "network-unavailable-condition-ensurer"
+      minAllowed:
+        cpu: 1m
+        memory: 20Mi
+      maxAllowed:
+        cpu: 10m
+        memory: 100Mi
+      controlledValues: RequestsOnly
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

Reset `NetworkUnavailable` condition after `calico-node` startup.

`calico-node` sets the `NetworkUnavailable` condition to `false` during startup and to `true` in a `PreStop` hook. This assumes that the `PreStop` hook always executes before a new instance comes up. Unfortunately, in some scenarios, this may be a race condition. Therefore, this change introduces a new side car container, which executes setting the condition some time after initial startup. It reuses the `calico-node` startup command, which seem to have no negative side-effects.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The race between a calico-node instance shutting down and a new one coming up is mitigated by setting `NetworkUnavailable` condition properly some time after initialization.
```
