### PR TITLE
Fix networkConfig for IPv6.

### DIFF
--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -93,23 +93,29 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, network *extens
 		}
 	}
 
+	if networkConfig == nil {
+		networkConfig = &calicov1alpha1.NetworkConfig{}
+	}
+
+	if ipFamilies.Has(extensionsv1alpha1.IPFamilyIPv4) {
+		if networkConfig.IPv4 == nil {
+			networkConfig.IPv4 = &calicov1alpha1.IPv4{}
+		}
+	}
+	if ipFamilies.Has(extensionsv1alpha1.IPFamilyIPv6) {
+		if networkConfig.IPv6 == nil {
+			networkConfig.IPv6 = &calicov1alpha1.IPv6{}
+		}
+	}
+
 	if cluster.Shoot.Spec.Networking != nil && cluster.Shoot.Spec.Networking.Nodes != nil && len(*cluster.Shoot.Spec.Networking.Nodes) > 0 {
 		autodetectionMode := fmt.Sprintf("cidr=%s", *cluster.Shoot.Spec.Networking.Nodes)
-		if networkConfig == nil {
-			networkConfig = &calicov1alpha1.NetworkConfig{}
-		}
 
 		if ipFamilies.Has(extensionsv1alpha1.IPFamilyIPv4) {
-			if networkConfig.IPv4 == nil {
-				networkConfig.IPv4 = &calicov1alpha1.IPv4{}
-			}
 			networkConfig.IPv4.AutoDetectionMethod = &autodetectionMode
 		}
 
 		if ipFamilies.Has(extensionsv1alpha1.IPFamilyIPv6) {
-			if networkConfig.IPv6 == nil {
-				networkConfig.IPv6 = &calicov1alpha1.IPv6{}
-			}
 			networkConfig.IPv6.AutoDetectionMethod = &autodetectionMode
 		}
 	}


### PR DESCRIPTION
`networkConfig` should be there, even if `Networking.Nodes` is not configured.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix networkConfig for IPv6.
```
