### PR TITLE
Adjust resource requests and autoscaling of `calico-node` side car containers.

### DIFF
--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -171,10 +171,6 @@ spec:
           env:
           - name: POD_CIDR
             value: {{ .Values.global.podCIDR }}
-          resources:
-            requests:
-              cpu: 10m
-              memory: 50Mi
           command:
           - /bin/sh
           - -c
@@ -238,10 +234,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          resources:
-            requests:
-              cpu: 1m
-              memory: 20Mi
           command:
             - /bin/sh
             - -c

--- a/charts/internal/calico/templates/node/vpa.yaml
+++ b/charts/internal/calico/templates/node/vpa.yaml
@@ -14,25 +14,5 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: calico-node
-      minAllowed:
-        memory: 50Mi
-      maxAllowed:
-        memory: 2800Mi
-      controlledValues: RequestsOnly
-    - containerName: "add-snat-rule-to-upstream-dns"
-      minAllowed:
-        cpu: 10m
-        memory: 50Mi
-      maxAllowed:
-        cpu: 1
-        memory: 1G
-      controlledValues: RequestsOnly
-    - containerName: "network-unavailable-condition-ensurer"
-      minAllowed:
-        cpu: 1m
-        memory: 20Mi
-      maxAllowed:
-        cpu: 10m
-        memory: 100Mi
       controlledValues: RequestsOnly
 {{- end }}

--- a/charts/internal/calico/templates/node/vpa.yaml
+++ b/charts/internal/calico/templates/node/vpa.yaml
@@ -15,4 +15,8 @@ spec:
     containerPolicies:
     - containerName: calico-node
       controlledValues: RequestsOnly
+    - containerName: "add-snat-rule-to-upstream-dns"
+      mode: "Off"
+    - containerName: "network-unavailable-condition-ensurer"
+      mode: "Off"
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

Adjust resource requests and autoscaling of `calico-node` side car containers.

The side car containers use negligible amount of resources compared to `calico-node`. Therefore, requests likely just waste resources. Similarly, they fall below the minimum threshold of VPA. Hence, autoscaling them does not make sense.
`minAllowed` and `maxAllowed` of `calico-node` also are not that useful. Therefore, they are removed as well.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
In VPA autoscaling mode, `calico-node` should be disrupted less often as side car containers are no longer considered by VPA. Additionally, the minimum/maximum restriction are removed, which can lead to less memory consumption.
```
