### PR TITLE
set correct iptables rules when using ipv6

### DIFF
--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -184,8 +184,13 @@ spec:
             sleep 15
             while true; do
               for i in $(cat /etc/resolv.conf | grep nameserver | sed -n -e 's/^.*nameserver //p' ); do
-                iptables-$backend -t nat -C POSTROUTING -s ${POD_CIDR} -d $i/32 ! -o cali+ -m comment --comment "calico masquerade non-cluster" -j MASQUERADE 2>/dev/null \
-                || iptables-$backend -t nat -I POSTROUTING 1 -s ${POD_CIDR} -d $i/32 ! -o cali+ -m comment --comment "calico masquerade non-cluster" -j MASQUERADE
+                if [[ $i =~ .*:.* ]] && [[ ${POD_CIDR} =~ .*:.* ]]; then
+                  ip6tables-$backend -t nat -C POSTROUTING -s ${POD_CIDR} -d $i/128 ! -o cali+ -m comment --comment "calico masquerade non-cluster" -j MASQUERADE 2>/dev/null \
+                  || ip6tables-$backend -t nat -I POSTROUTING 1 -s ${POD_CIDR} -d $i/128 ! -o cali+ -m comment --comment "calico masquerade non-cluster" -j MASQUERADE
+                elif [[ $i =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ ${POD_CIDR} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+                  iptables-$backend -t nat -C POSTROUTING -s ${POD_CIDR} -d $i/32 ! -o cali+ -m comment --comment "calico masquerade non-cluster" -j MASQUERADE 2>/dev/null \
+                  || iptables-$backend -t nat -I POSTROUTING 1 -s ${POD_CIDR} -d $i/32 ! -o cali+ -m comment --comment "calico masquerade non-cluster" -j MASQUERADE
+                fi
               done
               sleep 60
             done


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Correct iptable backend and iptable rule are set for IPv6 shoot clusters when running with node-local-dns.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Correct iptable backend and iptable rule are set for IPv6 shoot clusters when running with node-local-dns.
```
