### PR TITLE
Sanity Check for dual-stack before use IPAM.CIDR 

### DIFF
--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -311,7 +311,7 @@ func mergeCalicoValuesWithConfig(c *calicoConfig, config *calicov1alpha1.Network
 	}
 
 	if c.IPAM.IPAMType == hostLocal {
-		if config.IPAM != nil && config.IPAM.CIDR != nil {
+		if config.IPAM != nil && config.IPAM.CIDR != nil && !(isIPv4 && isIPv6) {
 			c.IPAM.Subnet = string(*config.IPAM.CIDR)
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

This PR introduces a boolean check to determine if the cluster is dual-stack. This check prevents misconfiguration when the user specifies an `ipam.cidr` value. If `ipam.cidr` is set , it will lead to an erroneous Calico configuration for dual-stack clusters.

Example configuration:

```yaml
networking:
  ipFamilies:
    - IPv4
    - IPv6
  type: calico
  nodes: 10.250.0.0/16
  providerConfig:
    apiVersion: calico.networking.extensions.gardener.cloud/v1alpha1
    kind: NetworkConfig
    ipam:
      type: host-local
      cidr: usePodCIDR
```

In this setup, specifying `ipam.cidr` can result in the Calico configuration containing incorrect `ranges` and `subnet` fields (an invalid configuration for dual-stack networks).

/area networking
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
