### PR TITLE
Allow running without overlay configuration.

### DIFF
--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -128,8 +128,8 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, network *extens
 		}
 	}
 
-	if networkConfig != nil && networkConfig.Overlay != nil {
-		if networkConfig.Overlay.Enabled {
+	if networkConfig != nil {
+		if networkConfig.Overlay != nil && networkConfig.Overlay.Enabled {
 			if ipFamilies.Has(extensionsv1alpha1.IPFamilyIPv4) {
 				networkConfig.IPv4.Mode = (*calicov1alpha1.PoolMode)(pointer.String(string(calicov1alpha1.Always)))
 			}
@@ -144,7 +144,7 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, network *extens
 			if ipFamilies.Has(extensionsv1alpha1.IPFamilyIPv6) {
 				networkConfig.IPv6.Mode = (*calicov1alpha1.PoolMode)(pointer.String(string(calicov1alpha1.Never)))
 			}
-			if networkConfig.Overlay.CreatePodRoutes != nil && *networkConfig.Overlay.CreatePodRoutes {
+			if networkConfig.Overlay != nil && networkConfig.Overlay.CreatePodRoutes != nil && *networkConfig.Overlay.CreatePodRoutes {
 				networkConfig.Backend = (*calicov1alpha1.Backend)(pointer.String(string(calicov1alpha1.Bird)))
 			} else {
 				networkConfig.Backend = (*calicov1alpha1.Backend)(pointer.String(string(calicov1alpha1.None)))

--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -129,25 +129,20 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, network *extens
 	}
 
 	if networkConfig != nil {
-		if networkConfig.Overlay != nil && networkConfig.Overlay.Enabled {
-			if ipFamilies.Has(extensionsv1alpha1.IPFamilyIPv4) {
-				networkConfig.IPv4.Mode = (*calicov1alpha1.PoolMode)(pointer.String(string(calicov1alpha1.Always)))
-			}
-			if ipFamilies.Has(extensionsv1alpha1.IPFamilyIPv6) {
-				networkConfig.IPv6.Mode = (*calicov1alpha1.PoolMode)(pointer.String(string(calicov1alpha1.Always)))
-			}
-			networkConfig.Backend = (*calicov1alpha1.Backend)(pointer.String(string(calicov1alpha1.Bird)))
-		} else {
-			if ipFamilies.Has(extensionsv1alpha1.IPFamilyIPv4) {
-				networkConfig.IPv4.Mode = (*calicov1alpha1.PoolMode)(pointer.String(string(calicov1alpha1.Never)))
-			}
-			if ipFamilies.Has(extensionsv1alpha1.IPFamilyIPv6) {
-				networkConfig.IPv6.Mode = (*calicov1alpha1.PoolMode)(pointer.String(string(calicov1alpha1.Never)))
-			}
-			if networkConfig.Overlay != nil && networkConfig.Overlay.CreatePodRoutes != nil && *networkConfig.Overlay.CreatePodRoutes {
-				networkConfig.Backend = (*calicov1alpha1.Backend)(pointer.String(string(calicov1alpha1.Bird)))
+		if networkConfig.Overlay != nil {
+			if networkConfig.Overlay.Enabled {
+				setPoolMode(networkConfig, ipFamilies, calicov1alpha1.Always)
 			} else {
-				networkConfig.Backend = (*calicov1alpha1.Backend)(pointer.String(string(calicov1alpha1.None)))
+				setPoolMode(networkConfig, ipFamilies, calicov1alpha1.Never)
+				if networkConfig.Overlay.CreatePodRoutes != nil && *networkConfig.Overlay.CreatePodRoutes {
+					networkConfig.Backend = (*calicov1alpha1.Backend)(pointer.String(string(calicov1alpha1.Bird)))
+				}
+			}
+		} else {
+			if ipFamilies.Has(extensionsv1alpha1.IPFamilyIPv6) {
+				setPoolMode(networkConfig, ipFamilies, calicov1alpha1.Never)
+			} else {
+				setPoolMode(networkConfig, ipFamilies, calicov1alpha1.Always)
 			}
 		}
 	}
@@ -199,6 +194,20 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, network *extens
 	}
 
 	return a.updateProviderStatus(ctx, network, networkConfig)
+}
+
+func setPoolMode(networkConfig *calicov1alpha1.NetworkConfig, ipFamilies sets.Set[extensionsv1alpha1.IPFamily], mode calicov1alpha1.PoolMode) {
+	if ipFamilies.Has(extensionsv1alpha1.IPFamilyIPv6) {
+		networkConfig.IPv6.Mode = (*calicov1alpha1.PoolMode)(pointer.String(string(mode)))
+	} else {
+		networkConfig.IPv4.Mode = (*calicov1alpha1.PoolMode)(pointer.String(string(mode)))
+	}
+
+	if mode == calicov1alpha1.Never {
+		networkConfig.Backend = (*calicov1alpha1.Backend)(pointer.String(string(calicov1alpha1.None)))
+	} else {
+		networkConfig.Backend = (*calicov1alpha1.Backend)(pointer.String(string(calicov1alpha1.Bird)))
+	}
 }
 
 func setAutoDetectionMethod(networkConfig *calicov1alpha1.NetworkConfig, ipFamilies sets.Set[extensionsv1alpha1.IPFamily], autodetectionMode string) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Without overlay configuration, a calico configuration without overlay but with bird is deployed. Bird creates unreachable routes, resulting in broken cross node traffic.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow running without overlay configuration.
```
