### PR TITLE
Make source network address translation configurable in IPv6 scenario.

### DIFF
--- a/charts/internal/calico/templates/ippool/ippool.yaml
+++ b/charts/internal/calico/templates/ippool/ippool.yaml
@@ -63,7 +63,7 @@ spec:
   blockSize: 122
   cidr: "{{ .Values.global.podCIDR }}"
   ipipMode: Never
-  natOutgoing: false
+  natOutgoing: {{ if .Values.config.ipv6.natOutgoing }}true{{ else }}false{{ end }}
   nodeSelector: all()
   vxlanMode: Never
 {{- end -}}

--- a/charts/internal/calico/values.yaml
+++ b/charts/internal/calico/values.yaml
@@ -31,7 +31,7 @@ config:
     pool: vxlan
     mode: "Never"
     autoDetectionMethod: "first-found"
-    natOutgoing: true
+    natOutgoing: false
     wireguard: false
   felix:
     ipinip:

--- a/hack/api-reference/calico.md
+++ b/hack/api-reference/calico.md
@@ -513,6 +513,19 @@ string
 <a href="https://docs.projectcalico.org/v3.8/reference/node/configuration#ip-autodetection-methods">https://docs.projectcalico.org/v3.8/reference/node/configuration#ip-autodetection-methods</a></p>
 </td>
 </tr>
+<tr>
+<td>
+<code>sourceNATEnabled</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SourceNATEnabled indicates whether the pod IP addresses should be masqueraded when targeting external destinations.
+Per default, source network address translation is disabled.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="calico.networking.extensions.gardener.cloud/v1alpha1.NetworkStatus">NetworkStatus

--- a/pkg/apis/calico/types_network.go
+++ b/pkg/apis/calico/types_network.go
@@ -62,6 +62,9 @@ type IPv6 struct {
 	// AutoDetectionMethod is the method to use to autodetect the IPv6 address for this host. This is only used when the IPv6 address is being autodetected.
 	// https://docs.projectcalico.org/v3.8/reference/node/configuration#ip-autodetection-methods
 	AutoDetectionMethod *string
+	// SourceNATEnabled indicates whether the pod IP addresses should be masqueraded when targeting external destinations.
+	// Per default, source network address translation is disabled.
+	SourceNATEnabled *bool
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/calico/v1alpha1/types_network.go
+++ b/pkg/apis/calico/v1alpha1/types_network.go
@@ -69,6 +69,10 @@ type IPv6 struct {
 	// https://docs.projectcalico.org/v3.8/reference/node/configuration#ip-autodetection-methods
 	// +optional
 	AutoDetectionMethod *string `json:"autoDetectionMethod,omitempty"`
+	// SourceNATEnabled indicates whether the pod IP addresses should be masqueraded when targeting external destinations.
+	// Per default, source network address translation is disabled.
+	// +optional
+	SourceNATEnabled *bool `json:"sourceNATEnabled,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/calico/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/calico/v1alpha1/zz_generated.conversion.go
@@ -240,6 +240,7 @@ func autoConvert_v1alpha1_IPv6_To_calico_IPv6(in *IPv6, out *calico.IPv6, s conv
 	out.Pool = (*calico.Pool)(unsafe.Pointer(in.Pool))
 	out.Mode = (*calico.PoolMode)(unsafe.Pointer(in.Mode))
 	out.AutoDetectionMethod = (*string)(unsafe.Pointer(in.AutoDetectionMethod))
+	out.SourceNATEnabled = (*bool)(unsafe.Pointer(in.SourceNATEnabled))
 	return nil
 }
 
@@ -252,6 +253,7 @@ func autoConvert_calico_IPv6_To_v1alpha1_IPv6(in *calico.IPv6, out *IPv6, s conv
 	out.Pool = (*Pool)(unsafe.Pointer(in.Pool))
 	out.Mode = (*PoolMode)(unsafe.Pointer(in.Mode))
 	out.AutoDetectionMethod = (*string)(unsafe.Pointer(in.AutoDetectionMethod))
+	out.SourceNATEnabled = (*bool)(unsafe.Pointer(in.SourceNATEnabled))
 	return nil
 }
 

--- a/pkg/apis/calico/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/calico/v1alpha1/zz_generated.deepcopy.go
@@ -122,6 +122,11 @@ func (in *IPv6) DeepCopyInto(out *IPv6) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SourceNATEnabled != nil {
+		in, out := &in.SourceNATEnabled, &out.SourceNATEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/calico/zz_generated.deepcopy.go
+++ b/pkg/apis/calico/zz_generated.deepcopy.go
@@ -122,6 +122,11 @@ func (in *IPv6) DeepCopyInto(out *IPv6) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SourceNATEnabled != nil {
+		in, out := &in.SourceNATEnabled, &out.SourceNATEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -481,7 +481,7 @@ var _ = Describe("Chart package test", func() {
 						"pool":                "vxlan",
 						"mode":                "Never",
 						"autoDetectionMethod": nil,
-						"natOutgoing":         true,
+						"natOutgoing":         false,
 						"wireguard":           false,
 					})),
 				))
@@ -519,7 +519,7 @@ var _ = Describe("Chart package test", func() {
 						"pool":                "vxlan",
 						"mode":                "CrossSubnet",
 						"autoDetectionMethod": "first-found",
-						"natOutgoing":         true,
+						"natOutgoing":         false,
 						"wireguard":           false,
 					})),
 				))
@@ -563,7 +563,7 @@ var _ = Describe("Chart package test", func() {
 						"pool":                "vxlan",
 						"mode":                "Never",
 						"autoDetectionMethod": nil,
-						"natOutgoing":         true,
+						"natOutgoing":         false,
 						"wireguard":           false,
 					})),
 				))

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -255,7 +255,7 @@ func generateChartValues(network *extensionsv1alpha1.Network, config *calicov1al
 			Pool:                calicov1alpha1.PoolVXLan,
 			Mode:                calicov1alpha1.Never,
 			AutoDetectionMethod: nil,
-			NATOutgoing:         true,
+			NATOutgoing:         false,
 		}
 		c.Felix.IPInIP.Enabled = false
 	}
@@ -391,6 +391,9 @@ func mergeCalicoValuesWithConfig(c *calicoConfig, config *calicov1alpha1.Network
 		}
 		if config.IPv6.AutoDetectionMethod != nil {
 			c.IPv6.AutoDetectionMethod = config.IPv6.AutoDetectionMethod
+		}
+		if config.IPv6.SourceNATEnabled != nil {
+			c.IPv6.NATOutgoing = *config.IPv6.SourceNATEnabled
 		}
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

Make source network address translation configurable in IPv6 scenario.

Previously, source network address translation (SNAT) was always disabled via the `IPPool` configuration in the IPv6 scenario. This should be a sensible default for scenarios when globally routable IPv6 address space is used. However, if unique local addresses (ULA) are used it might be useful to still perform source network address translation on the node level.
This change exposes an option so that SNAT can be enabled for IPv6.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow enablement of source network address translation in IPv6 scenarios.
```
