### PR TITLE
Fixed broken links - 2025.03

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -186,6 +186,6 @@ spec:
 
 ## Known Limitations in conjunction with `NodeLocalDNS`
 
-If [`NodeLocalDNS`](https://github.com/gardener/gardener/blob/master/docs/usage/node-local-dns.md) is active in a shoot cluster, which uses calico as CNI without overlay network, it may be impossible to block DNS traffic to the cluster DNS server via network policy. This is due to `FELIX_CHAININSERTMODE` being set to `APPEND` instead of `INSERT` in case SNAT is being applied to requests to the infrastructure DNS server. In this scenario the `iptables` rules of `NodeLocalDNS` already accept the traffic before the network policies are checked.
+If [`NodeLocalDNS`](https://github.com/gardener/gardener/blob/master/docs/usage/networking/node-local-dns.md) is active in a shoot cluster, which uses calico as CNI without overlay network, it may be impossible to block DNS traffic to the cluster DNS server via network policy. This is due to `FELIX_CHAININSERTMODE` being set to `APPEND` instead of `INSERT` in case SNAT is being applied to requests to the infrastructure DNS server. In this scenario the `iptables` rules of `NodeLocalDNS` already accept the traffic before the network policies are checked.
 
 This only applies to traffic directed to `NodeLocalDNS`. If blocking of all DNS traffic is desired via network policy the pod `dnsPolicy` should be changed to `Default` so that the cluster DNS is not used. Alternatives are usage of overlay network or disabling of `NodeLocalDNS`.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR fixes broken links in the documentation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
