### PR TITLE
Enable migration from single-stack IPv4 to dual-stack IPv4, IPv6.

### DIFF
--- a/hack/api-reference/calico.md
+++ b/hack/api-reference/calico.md
@@ -515,6 +515,16 @@ string
 </tr>
 </thead>
 <tbody>
+<tr>
+<td>
+<code>ipFamilies</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="calico.networking.extensions.gardener.cloud/v1alpha1.Overlay">Overlay

--- a/pkg/apis/calico/types_network.go
+++ b/pkg/apis/calico/types_network.go
@@ -111,6 +111,7 @@ type NetworkConfig struct {
 // NetworkStatus contains information about created Network resources.
 type NetworkStatus struct {
 	metav1.TypeMeta
+	ipFamilies []string
 }
 
 // IPAM defines the block that configuration for the ip assignment plugin to be used

--- a/pkg/apis/calico/types_network.go
+++ b/pkg/apis/calico/types_network.go
@@ -111,7 +111,7 @@ type NetworkConfig struct {
 // NetworkStatus contains information about created Network resources.
 type NetworkStatus struct {
 	metav1.TypeMeta
-	ipFamilies []string
+	IPFamilies []string
 }
 
 // IPAM defines the block that configuration for the ip assignment plugin to be used

--- a/pkg/apis/calico/v1alpha1/types_network.go
+++ b/pkg/apis/calico/v1alpha1/types_network.go
@@ -130,6 +130,7 @@ type NetworkConfig struct {
 // NetworkStatus contains information about created Network resources.
 type NetworkStatus struct {
 	metav1.TypeMeta `json:",inline"`
+	IPFamilies      []string `json:"ipFamilies"`
 }
 
 // IPAM defines the block that configuration for the ip assignment plugin to be used

--- a/pkg/apis/calico/v1alpha1/types_network.go
+++ b/pkg/apis/calico/v1alpha1/types_network.go
@@ -130,7 +130,7 @@ type NetworkConfig struct {
 // NetworkStatus contains information about created Network resources.
 type NetworkStatus struct {
 	metav1.TypeMeta `json:",inline"`
-	IPFamilies      []string `json:"ipFamilies"`
+	IPFamilies      []string `json:"ipFamilies,omitempty"`
 }
 
 // IPAM defines the block that configuration for the ip assignment plugin to be used

--- a/pkg/apis/calico/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/calico/v1alpha1/zz_generated.conversion.go
@@ -295,6 +295,7 @@ func Convert_calico_NetworkConfig_To_v1alpha1_NetworkConfig(in *calico.NetworkCo
 }
 
 func autoConvert_v1alpha1_NetworkStatus_To_calico_NetworkStatus(in *NetworkStatus, out *calico.NetworkStatus, s conversion.Scope) error {
+	out.IPFamilies = *(*[]string)(unsafe.Pointer(&in.IPFamilies))
 	return nil
 }
 
@@ -304,6 +305,7 @@ func Convert_v1alpha1_NetworkStatus_To_calico_NetworkStatus(in *NetworkStatus, o
 }
 
 func autoConvert_calico_NetworkStatus_To_v1alpha1_NetworkStatus(in *calico.NetworkStatus, out *NetworkStatus, s conversion.Scope) error {
+	out.IPFamilies = *(*[]string)(unsafe.Pointer(&in.IPFamilies))
 	return nil
 }
 

--- a/pkg/apis/calico/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/calico/v1alpha1/zz_generated.deepcopy.go
@@ -224,6 +224,11 @@ func (in *NetworkConfig) DeepCopyObject() runtime.Object {
 func (in *NetworkStatus) DeepCopyInto(out *NetworkStatus) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.IPFamilies != nil {
+		in, out := &in.IPFamilies, &out.IPFamilies
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/calico/zz_generated.deepcopy.go
+++ b/pkg/apis/calico/zz_generated.deepcopy.go
@@ -224,6 +224,11 @@ func (in *NetworkConfig) DeepCopyObject() runtime.Object {
 func (in *NetworkStatus) DeepCopyInto(out *NetworkStatus) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.IPFamilies != nil {
+		in, out := &in.IPFamilies, &out.IPFamilies
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -8,11 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"slices"
 	"strconv"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/gardener/gardener-extension-networking-calico/imagevector"
 	calicov1alpha1 "github.com/gardener/gardener-extension-networking-calico/pkg/apis/calico/v1alpha1"
@@ -162,7 +162,7 @@ func ComputeCalicoChartValues(
 	nonPrivileged bool,
 	nodeCIDR *string,
 	podCIDRs []string,
-	ipFamilies sets.Set[extensionsv1alpha1.IPFamily],
+	ipFamilies []extensionsv1alpha1.IPFamily,
 ) (map[string]interface{}, error) {
 	typedConfig, err := generateChartValues(network, config, kubeProxyEnabled, nonPrivileged, ipFamilies)
 	if err != nil {
@@ -227,10 +227,9 @@ func ComputeCalicoChartValues(
 	return calicoChartValues, nil
 }
 
-func generateChartValues(network *extensionsv1alpha1.Network, config *calicov1alpha1.NetworkConfig, kubeProxyEnabled bool, nonPrivileged bool, ipFamilies sets.Set[extensionsv1alpha1.IPFamily]) (*calicoConfig, error) {
-
-	isIPv4 := ipFamilies.Has(extensionsv1alpha1.IPFamilyIPv4)
-	isIPv6 := ipFamilies.Has(extensionsv1alpha1.IPFamilyIPv6)
+func generateChartValues(network *extensionsv1alpha1.Network, config *calicov1alpha1.NetworkConfig, kubeProxyEnabled bool, nonPrivileged bool, ipFamilies []extensionsv1alpha1.IPFamily) (*calicoConfig, error) {
+	isIPv4 := slices.Contains(ipFamilies, extensionsv1alpha1.IPFamilyIPv4)
+	isIPv6 := slices.Contains(ipFamilies, extensionsv1alpha1.IPFamilyIPv6)
 
 	c := newCalicoConfig()
 	if isIPv4 {

--- a/pkg/charts/values.go
+++ b/pkg/charts/values.go
@@ -27,8 +27,9 @@ func RenderCalicoChart(
 	nonPrivileged bool,
 	nodeCIDR *string,
 	podCidrs []string,
+	nodesMigrated bool,
 ) ([]byte, error) {
-	values, err := ComputeCalicoChartValues(network, config, kubernetesVersion, wantsVPA, kubeProxyEnabled, nonPrivileged, nodeCIDR, podCidrs)
+	values, err := ComputeCalicoChartValues(network, config, kubernetesVersion, wantsVPA, kubeProxyEnabled, nonPrivileged, nodeCIDR, podCidrs, nodesMigrated)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/charts/values.go
+++ b/pkg/charts/values.go
@@ -8,7 +8,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/gardener/gardener-extension-networking-calico/charts"
 	calicov1alpha1 "github.com/gardener/gardener-extension-networking-calico/pkg/apis/calico/v1alpha1"
@@ -28,7 +27,7 @@ func RenderCalicoChart(
 	nonPrivileged bool,
 	nodeCIDR *string,
 	podCidrs []string,
-	ipFamilies sets.Set[extensionsv1alpha1.IPFamily],
+	ipFamilies []extensionsv1alpha1.IPFamily,
 ) ([]byte, error) {
 	values, err := ComputeCalicoChartValues(network, config, kubernetesVersion, wantsVPA, kubeProxyEnabled, nonPrivileged, nodeCIDR, podCidrs, ipFamilies)
 	if err != nil {

--- a/pkg/charts/values.go
+++ b/pkg/charts/values.go
@@ -5,6 +5,7 @@
 package charts
 
 import (
+	"k8s.io/apimachinery/pkg/util/sets"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,9 +28,9 @@ func RenderCalicoChart(
 	nonPrivileged bool,
 	nodeCIDR *string,
 	podCidrs []string,
-	nodesMigrated bool,
+	ipFamilies sets.Set[extensionsv1alpha1.IPFamily],
 ) ([]byte, error) {
-	values, err := ComputeCalicoChartValues(network, config, kubernetesVersion, wantsVPA, kubeProxyEnabled, nonPrivileged, nodeCIDR, podCidrs, nodesMigrated)
+	values, err := ComputeCalicoChartValues(network, config, kubernetesVersion, wantsVPA, kubeProxyEnabled, nonPrivileged, nodeCIDR, podCidrs, ipFamilies)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/charts/values.go
+++ b/pkg/charts/values.go
@@ -5,10 +5,10 @@
 package charts
 
 import (
-	"k8s.io/apimachinery/pkg/util/sets"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/gardener/gardener-extension-networking-calico/charts"
 	calicov1alpha1 "github.com/gardener/gardener-extension-networking-calico/pkg/apis/calico/v1alpha1"

--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -95,7 +95,6 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, network *extens
 		}
 	}
 
-
 	condition := gardencorev1beta1helper.GetCondition(cluster.Shoot.Status.Constraints, "ToDualStackMigration")
 
 	if condition != nil && condition.Status != "DualStackNodesReady" {

--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -96,7 +96,9 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, network *extens
 	}
 
 	nodesMigrated := false
-	if cluster.Shoot.Annotations != nil && cluster.Shoot.Annotations["shoot.gardener.cloud/migrate-network"] != "true" {
+	condition := gardencorev1beta1helper.GetCondition(cluster.Shoot.Status.Constraints, "ToDualStackMigration")
+
+	if condition != nil && condition.Status != "True" {
 		nodesMigrated = true
 	}
 

--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -97,9 +97,7 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, network *extens
 		}
 	}
 
-	condition := gardencorev1beta1helper.GetCondition(cluster.Shoot.Status.Constraints, "DualStackNodesMigrationReady")
-
-	if condition != nil && condition.Status != v1beta1.ConditionTrue {
+	if condition := gardencorev1beta1helper.GetCondition(cluster.Shoot.Status.Constraints, "DualStackNodesMigrationReady"); condition != nil && condition.Status != v1beta1.ConditionTrue {
 		if len(ipFamilies) > 1 {
 			ipFamilies = ipFamilies[:1]
 		}
@@ -135,7 +133,6 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, network *extens
 
 			autodetectionModeV6 := updateAutoDetectionMode(ipv6Nodes)
 			setAutoDetectionMethodV6(networkConfig, ipFamilies, autodetectionModeV6)
-
 		}
 	}
 

--- a/pkg/controller/status.go
+++ b/pkg/controller/status.go
@@ -37,9 +37,17 @@ func (a *actuator) updateProviderStatus(
 }
 
 func (a *actuator) ComputeNetworkStatus(networkConfig *calicov1alpha1.NetworkConfig) (*calicov1alpha1.NetworkStatus, error) {
+	var ipFamilies []string
+	if networkConfig.IPv4 != nil {
+		ipFamilies = append(ipFamilies, string(extensionsv1alpha1.IPFamilyIPv4))
+	}
+	if networkConfig.IPv6 != nil {
+		ipFamilies = append(ipFamilies,string(extensionsv1alpha1.IPFamilyIPv6))
+	}
 	var (
 		status = &calicov1alpha1.NetworkStatus{
 			TypeMeta: StatusTypeMeta,
+			IPFamilies: ipFamilies,
 		}
 	)
 

--- a/pkg/controller/status.go
+++ b/pkg/controller/status.go
@@ -42,11 +42,11 @@ func (a *actuator) ComputeNetworkStatus(networkConfig *calicov1alpha1.NetworkCon
 		ipFamilies = append(ipFamilies, string(extensionsv1alpha1.IPFamilyIPv4))
 	}
 	if networkConfig.IPv6 != nil {
-		ipFamilies = append(ipFamilies,string(extensionsv1alpha1.IPFamilyIPv6))
+		ipFamilies = append(ipFamilies, string(extensionsv1alpha1.IPFamilyIPv6))
 	}
 	var (
 		status = &calicov1alpha1.NetworkStatus{
-			TypeMeta: StatusTypeMeta,
+			TypeMeta:   StatusTypeMeta,
 			IPFamilies: ipFamilies,
 		}
 	)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
To migrate shoots from single stack IPv4 to dual-stack IPv4,IPv6 networking, we track the current migration state in the shoot state. This PR adds checks to read the respective constraint in the shoot and configure components accordingly.
In addition, it writes the effective IPFamilies to the status of the `network` resource.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add support for single-stack to dual-stack networking migration.
```
