### PR TITLE
Update base image to `debian12`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,14 @@ ARG EFFECTIVE_VERSION
 RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
 
 ############# gardener-extension-networking-calico
-FROM gcr.io/distroless/static-debian11:nonroot AS gardener-extension-networking-calico
+FROM gcr.io/distroless/static-debian12:nonroot AS gardener-extension-networking-calico
 WORKDIR /
 
 COPY --from=builder /go/bin/gardener-extension-networking-calico /gardener-extension-networking-calico
 ENTRYPOINT ["/gardener-extension-networking-calico"]
 
 ############# gardener-extension-admission-calico
-FROM gcr.io/distroless/static-debian11:nonroot AS gardener-extension-admission-calico
+FROM gcr.io/distroless/static-debian12:nonroot AS gardener-extension-admission-calico
 WORKDIR /
 
 COPY --from=builder /go/bin/gardener-extension-admission-calico /gardener-extension-admission-calico


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Update base image from `debian11` to `debian12` to get current set of CA certificates.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update base image from `debian11` to `debian12`.
```
