### PR TITLE
Prepare Calico for deny all network policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ EFFECTIVE_VERSION           := $(VERSION)-$(shell git rev-parse HEAD)
 LD_FLAGS                    := "-w $(shell bash $(GARDENER_HACK_DIR)/get-build-ld-flags.sh "" $(REPO_ROOT)/VERSION "$(EXTENSION_PREFIX)")"
 LEADER_ELECTION             := false
 IGNORE_OPERATION_ANNOTATION := true
+ARCH                		?= amd64
 
 ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
 	EFFECTIVE_VERSION := $(EFFECTIVE_VERSION)-dirty
@@ -78,8 +79,8 @@ docker-login:
 
 .PHONY: docker-images
 docker-images:
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(NAME):$(VERSION)           -t $(IMAGE_PREFIX)/$(NAME):latest           -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(NAME)           .
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(ADMISSION_NAME) .
+	@docker build --platform=linux/$(ARCH) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(NAME):$(VERSION)           -t $(IMAGE_PREFIX)/$(NAME):latest           -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(NAME)           .
+	@docker build --platform=linux/$(ARCH) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(ADMISSION_NAME) .
 
 #####################################################################
 # Rules for verification, formatting, linting, testing and cleaning #

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ EFFECTIVE_VERSION           := $(VERSION)-$(shell git rev-parse HEAD)
 LD_FLAGS                    := "-w $(shell bash $(GARDENER_HACK_DIR)/get-build-ld-flags.sh "" $(REPO_ROOT)/VERSION "$(EXTENSION_PREFIX)")"
 LEADER_ELECTION             := false
 IGNORE_OPERATION_ANNOTATION := true
-ARCH                		?= amd64
+ARCH                        ?= amd64
 
 ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
 	EFFECTIVE_VERSION := $(EFFECTIVE_VERSION)-dirty

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -32,7 +32,7 @@ func defaultShootCreationFramework() *framework.ShootCreationFramework {
 		GardenerConfig: &framework.GardenerConfig{
 			ProjectNamespace:   projectNamespace,
 			GardenerKubeconfig: kubeconfigPath,
-			SkipAccessingShoot: true,
+			SkipAccessingShoot: false,
 			CommonConfig:       &framework.CommonConfig{},
 		},
 	})
@@ -49,9 +49,12 @@ func defaultShoot(generateName string) *gardencorev1beta1.Shoot {
 		Spec: gardencorev1beta1.ShootSpec{
 			Region:            "local",
 			SecretBindingName: pointer.String("local"),
-			CloudProfileName:  pointer.String("local"),
+			CloudProfile: &gardencorev1beta1.CloudProfileReference{
+				Name: "local",
+				Kind: "CloudProfile",
+			},
 			Kubernetes: gardencorev1beta1.Kubernetes{
-				Version:                     "1.29.0",
+				Version: "1.29.0",
 				Kubelet: &gardencorev1beta1.KubeletConfig{
 					SerializeImagePulls: pointer.Bool(false),
 					RegistryPullQPS:     pointer.Int32(10),
@@ -77,6 +80,11 @@ func defaultShoot(generateName string) *gardencorev1beta1.Shoot {
 					Minimum: 2,
 					Maximum: 2,
 				}},
+			},
+			SystemComponents: &gardencorev1beta1.SystemComponents{
+				NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{
+					Enabled: true,
+				},
 			},
 		},
 	}

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/gardener/gardener-extension-networking-calico/test/templates"
@@ -33,6 +35,20 @@ var _ = Describe("Network Extension Tests", Label("Network"), func() {
 		Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 		f.Verify()
 
+		By("Create Deny-All Network Policy")
+		denyAllPolicy := &networkingv1.NetworkPolicy{
+			ObjectMeta: v1.ObjectMeta{Name: "deny-all", Namespace: "kube-system"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: v1.LabelSelector{},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+				Ingress:     []networkingv1.NetworkPolicyIngressRule{},
+				Egress:      []networkingv1.NetworkPolicyEgressRule{},
+			},
+		}
+		err := f.ShootFramework.ShootClient.Client().Create(ctx, denyAllPolicy)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Test Network")
 		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
 		defer cancel()
 		succeeded := testNetwork(ctx, f)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind test

**What this PR does / why we need it**:

- This PR enhances the existing test suite to make sure Calico still works with a `deny-all` network policy coming to kube-system in K8S 1.33

- Also enabled node-local DNS for the test shoots as it is most commonly used today


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Calico extension now supports a deny-all network policy within the kube-system namespace that [will come with kubernetes v1.33](https://github.com/gardener/gardener/pull/11502)
```
