### PR TITLE
Fix roles in `ScrapeConfig`s

### DIFF
--- a/charts/internal/calico-monitoring/templates/scrapeconfig-felix.yaml
+++ b/charts/internal/calico-monitoring/templates/scrapeconfig-felix.yaml
@@ -25,7 +25,7 @@ spec:
     namespaces:
       names:
       - kube-system
-    role: endpoints
+    role: Endpoints
     tlsConfig:
       # This is needed because we do not fetch the correct cluster CA bundle right now
       insecureSkipVerify: true

--- a/charts/internal/calico-monitoring/templates/scrapeconfig-typha.yaml
+++ b/charts/internal/calico-monitoring/templates/scrapeconfig-typha.yaml
@@ -25,7 +25,7 @@ spec:
     namespaces:
       names:
       - kube-system
-    role: endpoints
+    role: Endpoints
     tlsConfig:
       # This is needed because we do not fetch the correct cluster CA bundle right now
       insecureSkipVerify: true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Since [`github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring@v0.76.0`](https://github.com/prometheus-operator/prometheus-operator/releases/tag/pkg/apis/monitoring/v0.76.0) only camel case roles are valid in `ScrapeConfig`s of `monitoring.coreos.com/v1alpha1` ([ref](https://github.com/prometheus-operator/prometheus-operator/commit/38900ce#diff-95caef4dacf48c47bf56afc00c513822feba29a5d2f6354b75c97a25a353d52fL75-R77)).
The old lower-case-only roles which are quite common in Gardener components are not valid anymore.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/12401

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
