### PR TITLE
Drop support for Shoots with Kubernetes version <= 1.28

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -172,7 +172,7 @@ spec:
       typha:
         enabled: false
   kubernetes:
-    version: 1.28.3
+    version: 1.32.0
   maintenance:
     autoUpdate:
       kubernetesVersion: true

--- a/example/20-network.yaml
+++ b/example/20-network.yaml
@@ -28,7 +28,7 @@ spec:
       dns:
         domain: foo.bar.example.com
       kubernetes:
-        version: 1.28.3
+        version: 1.32.0
     status:
       lastOperation:
         state: Succeeded

--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -32,7 +32,7 @@ var (
 
 var _ = Describe("Chart package test", func() {
 	var (
-		kubernetesVersion                           = "1.28.0"
+		kubernetesVersion                           = "1.29.0"
 		podCIDR                                     = calicov1alpha1.CIDR("12.0.0.0/8")
 		nodeCIDR                                    = "10.250.0.0/8"
 		usePodCidr                                  = calicov1alpha1.CIDR("usePodCidr")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/area networking

**What this PR does / why we need it**:
Drop support for Shoots, Seeds and Gardens with Kubernetes version <= 1.28.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/12409

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
`networking-calico` no longer supports Shoots with Кubernetes version <= 1.28.
```
