### PR TITLE
Fix a bug that prevented Prometheus from storing Calico metrics

### DIFF
--- a/charts/internal/calico-monitoring/templates/scrapeconfig-felix.yaml
+++ b/charts/internal/calico-monitoring/templates/scrapeconfig-felix.yaml
@@ -34,10 +34,6 @@ spec:
     - __name__
     action: keep
     regex: felix_.+
-  - sourceLabels:
-    - namespace
-    action: keep
-    regex: kube-system
   relabelings:
   - action: replace
     replacement: felix-metrics

--- a/charts/internal/calico-monitoring/templates/scrapeconfig-typha.yaml
+++ b/charts/internal/calico-monitoring/templates/scrapeconfig-typha.yaml
@@ -34,10 +34,6 @@ spec:
     - __name__
     action: keep
     regex: typha_.+
-  - sourceLabels:
-    - namespace
-    action: keep
-    regex: kube-system
   relabelings:
   - action: replace
     replacement: typha-metrics


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
In ed36c27, an additional snippet was added to the metricRelabelings part of the Prometheus scrape config that instructed Prometheus to keep only metrics where the `namespace` label was set to `kube-system`. When Prometheus is configured to `keep` a subset of the metrics, it drops all metrics that aren't kept.
The issue with this is that the `__meta_kubernetes_namespace` label isn't replaced with the `namespace` label. In fact that would be unnecessary because the calico-node pods only run in the `kube-system` namespace. Therefore this commit simply removes the `keep` instruction for the non-existent `namespace` label.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
FYI @ScheererJ 
Incredible @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixes a bug in Prometheus ScrapeConfigs that prevented Calico metrics from being collected.
```
