### PR TITLE
Use separate port for healthz endpoint if running in ebpf mode with kube-proxy

### DIFF
--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -383,6 +383,13 @@ spec:
             # Enable eBPF dataplane mode.
             - name: FELIX_BPFENABLED
               value: "{{ .Values.config.felix.bpf.enabled }}"
+            # Move Kube-proxy healthz endpoint of calico-node to a different port when running in eBPF mode and kube-proxy is enabled.
+            {{- if and .Values.config.felix.bpf.enabled (not .Values.config.felix.bpfKubeProxyIPTablesCleanup.enabled) }}
+            - name: FELIX_BPFKUBEPROXYHEALTZPORT
+              value: "10257"
+            - name: FELIX_BPFKUBEPROXYHEALTHZPORT
+              value: "10257"
+            {{- end }}
             # Controls whether Felix will clean up the iptables rules created by the Kubernetes kube-proxy; should only be enabled if kube-proxy is not running.
             - name: FELIX_BPFKUBEPROXYIPTABLESCLEANUPENABLED
               value: "{{ .Values.config.felix.bpfKubeProxyIPTablesCleanup.enabled }}"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

Use separate port for healthz endpoint if running in ebpf mode with kube-proxy.

In ebpf mode `calico-node` has to expose the healthz endpoint for load balancers if it takes over service routing, i.e. if `kube-proxy` is not running. However, it should not clash with `kube-proxy` if running in ebpf mode together with `kube-proxy`. Therefore, we set the healthz endpoint to a different port in this case.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Setting the environment with typo as with the actual change (see https://github.com/projectcalico/calico/issues/10748) and with the proper spelling in case it gets corrected.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`calico-node` should not longer bind to the `kube-proxy` healthz port if used in ebpf mode and `kube-proxy` is enabled.
```
