### PR TITLE
disable ipinip if overlay is set

### DIFF
--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -292,6 +292,11 @@ func generateChartValues(network *extensionsv1alpha1.Network, config *calicov1al
 		)
 	}
 
+	// Disable IP-in-IP if overlay is disabled
+	if config != nil && config.Overlay != nil && !config.Overlay.Enabled {
+		c.Felix.IPInIP.Enabled = false
+	}
+
 	if !kubeProxyEnabled {
 		c.Felix.BPFKubeProxyIptablesCleanup.Enabled = true
 	}
@@ -321,6 +326,7 @@ func mergeCalicoValuesWithConfig(c *calicoConfig, config *calicov1alpha1.Network
 			return nil, fmt.Errorf("unsupported value for backend: %s", *config.Backend)
 		}
 	}
+
 	if c.Backend == calicov1alpha1.None {
 		c.KubeControllers.Enabled = false
 		c.Felix.IPInIP.Enabled = false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Ensure `FELIX_IPINIPENABLED` is set to false in all cases if overlay is disabled. 


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Ensure `FELIX_IPINIPENABLED` is set to false in all cases if overlay is disabled. 
```
