### PR TITLE
feat: log dropped packets due to MTU issues

### DIFF
--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -61,6 +61,35 @@ spec:
         securityContext:
           privileged: true
       {{- end }}
+      # Log MTU issues if monitoring is enabled
+      {{- if .Values.config.monitoring.enabled }}
+      - name: log-mtu-issues
+        image: {{ index .Values.images "calico-node" }}
+        command:
+          - /bin/sh
+          - -c
+          - |
+            nft_kubelet_rules=$( (iptables-nft-save -t mangle; ip6tables-nft-save -t mangle ) 2>/dev/null | grep -E '^:(KUBE-IPTABLES-HINT|KUBE-KUBELET-CANARY)')
+            if [ -n "$nft_kubelet_rules" ]; then
+              backend="nft"
+            else
+              backend="legacy"
+            fi
+            rulespecV4=("-p" "icmp" "--icmp-type" "fragmentation-needed" "-m" "comment" "--comment" "gardener log mtu problems for ipv4" "-j" "LOG" "--log-prefix" "PACKET-TOO-BIG ")
+            rulespecV6=("-p" "ipv6-icmp" "--icmpv6-type" "packet-too-big" "-m" "comment" "--comment" "gardener log mtu problems for ipv6" "-j" "LOG" "--log-prefix" "PACKET-TOO-BIG ")
+            if iptables-$backend -t filter -C OUTPUT "${rulespecV4[@]}" 2>/dev/null; then
+              echo "IPv4 MTU logging rule already exists"
+            else
+              iptables-$backend -t filter -I OUTPUT "${rulespecV4[@]}"
+            fi
+            if ip6tables-$backend -t filter -C OUTPUT "${rulespecV6[@]}" 2>/dev/null; then
+              echo "IPv6 MTU logging rule already exists"
+            else
+              ip6tables-$backend -t filter -I OUTPUT "${rulespecV6[@]}"
+            fi
+        securityContext:
+          privileged: true
+      {{- end }}
       # This container installs the CNI binaries
       # and CNI network config file on each node.
       - name: install-cni


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
- We've seen several connectivity issues with overlay clusters and VPN in the past.
- We were able to rca those issues to wrong MTU/MSS values set on tcp connections forwarded by VPN
- The issues got fixed, however this PR will add more observability in case similar issues arise in the future
- The PR installs an iptables logging rule to calico clusters that prints a `PACKET-TOO-BIG` line to the kernel log in case a `fragentation-needed` (v4) or `packet-too-big` (v6) packets was issued by the local host due to bad MTU settings.
- The PACKET-TOO-BIG string can be easily searched for in plutono/vali if needed.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Calico clusters will now report MTU issues to the kernel log using a PACKET-TOO-BIG prefix.
```
