### PR TITLE
Reduce the size of the cni-plugins container image.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,6 +57,18 @@ jobs:
                 confidentiality_requirement: low
                 integrity_requirement: high
                 availability_requirement: high
+          - name: cni-plugins
+            target: cni-plugins
+            oci-repository: gardener/extensions/cni-plugins
+            ocm-labels:
+              name: gardener.cloud/cve-categorisation
+              value:
+                network_exposure: protected
+                authentication_enforced: false
+                user_interaction: end-user
+                confidentiality_requirement: low
+                integrity_requirement: high
+                availability_requirement: low
     with:
       name: ${{ matrix.args.name }}
       version: ${{ needs.prepare.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,3 +27,19 @@ WORKDIR /
 
 COPY --from=builder /go/bin/gardener-extension-admission-calico /gardener-extension-admission-calico
 ENTRYPOINT ["/gardener-extension-admission-calico"]
+
+############# cni-plugins-builder
+FROM ghcr.io/k8snetworkplumbingwg/plugins:v1.6.2 AS cni-plugins-original
+FROM scratch AS cni-plugins-builder
+WORKDIR /
+
+COPY --from=cni-plugins-original /entrypoint.sh /
+COPY --from=cni-plugins-original /usr/src/cni/bin/* /usr/src/cni/bin/
+
+############# cni-plugins
+FROM alpine:3.22.2 AS cni-plugins
+WORKDIR /
+LABEL io.k8s.display-name="Container Network Plugins"
+
+COPY --from=cni-plugins-builder / /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ GARDENER_HACK_DIR    		:= $(shell go list -m -f "{{.Dir}}" github.com/gardener/g
 EXTENSION_PREFIX            := gardener-extension
 NAME                        := networking-calico
 ADMISSION_NAME              := admission-calico
+CNI_PLUGINS_NAME            := cni-plugins
 REGISTRY                    := europe-docker.pkg.dev/gardener-project/public/gardener
 IMAGE_PREFIX                := $(REGISTRY)/extensions
 REPO_ROOT                   := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
@@ -79,8 +80,9 @@ docker-login:
 
 .PHONY: docker-images
 docker-images:
-	@docker build --platform=linux/$(ARCH) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(NAME):$(VERSION)           -t $(IMAGE_PREFIX)/$(NAME):latest           -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(NAME)           .
-	@docker build --platform=linux/$(ARCH) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(ADMISSION_NAME) .
+	@docker build --platform=linux/$(ARCH) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(NAME):$(VERSION)             -t $(IMAGE_PREFIX)/$(NAME):latest             -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(NAME)           .
+	@docker build --platform=linux/$(ARCH) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):$(VERSION)   -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):latest   -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(ADMISSION_NAME) .
+	@docker build --platform=linux/$(ARCH) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(CNI_PLUGINS_NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(CNI_PLUGINS_NAME):latest -f Dockerfile -m 6g --target $(CNI_PLUGINS_NAME)                   .
 
 #####################################################################
 # Rules for verification, formatting, linting, testing and cleaning #

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -108,15 +108,7 @@ images:
         integrity_requirement: 'high'
         availability_requirement: 'low'
 - name: cni-plugins
-  sourceRepository: github.com/k8snetworkplumbingwg/plugins
-  repository: ghcr.io/k8snetworkplumbingwg/plugins
-  tag: v1.6.2
-  labels:
-    - name: 'gardener.cloud/cve-categorisation'
-      value:
-        network_exposure: 'protected'
-        authentication_enforced: false
-        user_interaction: 'end-user'
-        confidentiality_requirement: 'low'
-        integrity_requirement: 'high'
-        availability_requirement: 'low'
+  sourceRepository: github.com/gardener/gardener-extension-networking-calico
+  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/cni-plugins
+  resourceId:
+    name: cni-plugins


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

Reduce the size of the cni-plugins container image.

The cni-plugins container used with multus is unnecessarily large and contains a lot more than required. It actually only needs to include the cni binaries, a shell, a copy and sleep command.
This change creates a new container image based on the original including only what is needed on top of an alpine base image.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Reduced size of the cni-plugins container image significantly.
```
