### PR TITLE
fix: don't create VPA for Typha when it is disabled

### DIFF
--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -187,7 +187,7 @@ func ComputeCalicoChartValues(
 	if err != nil {
 		return nil, fmt.Errorf("error when generating calico config: %v", err)
 	}
-	calicoConfig, err := typedConfig.toMap()
+	calicoCfg, err := typedConfig.toMap()
 	if err != nil {
 		return nil, fmt.Errorf("could not convert calico config: %v", err)
 	}
@@ -209,7 +209,7 @@ func ComputeCalicoChartValues(
 		"global": map[string]string{
 			"podCIDR": network.Spec.PodCIDR,
 		},
-		"config": calicoConfig,
+		"config": calicoCfg,
 	}
 
 	for _, podCIDR := range podCIDRs {
@@ -244,7 +244,9 @@ func ComputeCalicoChartValues(
 
 	if config != nil && config.AutoScaling != nil && config.AutoScaling.Mode == calicov1alpha1.AutoscalingModeVPA && wantsVPA {
 		calicoChartValues["autoscaling"].(map[string]interface{})["node"] = strconv.FormatBool(true)
-		calicoChartValues["autoscaling"].(map[string]interface{})["typha"] = strconv.FormatBool(true)
+		if typedConfig.Typha.Enabled {
+			calicoChartValues["autoscaling"].(map[string]interface{})["typha"] = strconv.FormatBool(true)
+		}
 		calicoChartValues["autoscaling"].(map[string]interface{})["resourceRequests"] = calculateResourceRequests(config.AutoScaling.Resources)
 	} else if config != nil && config.AutoScaling != nil && config.AutoScaling.Mode == calicov1alpha1.AutoscalingModeStatic {
 		calicoChartValues["autoscaling"].(map[string]interface{})["staticRequests"] = strconv.FormatBool(true)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:

- Only generate VPA config for Typha if it is actually enabled

**Which issue(s) this PR fixes**:
Fixes #758 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Calico won't create a VPA configuration for Typha when it is disabled
```
