### PR TITLE
support NFTables in calico

### DIFF
--- a/charts/internal/calico/templates/node/daemonset-calico-node.yaml
+++ b/charts/internal/calico/templates/node/daemonset-calico-node.yaml
@@ -431,6 +431,10 @@ spec:
             - name: FELIX_SERVICELOOPPREVENTION
               value: "{{ .Values.config.felix.serviceLoopPrevention }}"
             {{- end }}
+            {{- if .Values.config.felix.nftables.enabled }}
+            - name: FELIX_NFTABLESMODE
+              value: "Enabled"
+            {{- end }}
             {{- if eq .Values.global.snatToUpstreamDNSEnabled "true" }}
             - name: FELIX_CHAININSERTMODE
               value: "Append"

--- a/charts/internal/calico/values.yaml
+++ b/charts/internal/calico/values.yaml
@@ -41,6 +41,8 @@ config:
       enabled: "true"
     bpf:
       enabled: "false"
+    nftables:
+      enabled: false
     bpfKubeProxyIPTablesCleanup:
       enabled: "false"
   nonPrivileged: false

--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -243,7 +243,7 @@ var _ = Describe("Chart package test", func() {
 		func(config func() *calicov1alpha1.NetworkConfig, configResult func() *calicov1alpha1.NetworkConfig, typhaEnabled bool, wantsVPA bool,
 			kubeProxyEnabled bool, mtu string, ipinip bool, bpf bool, pool string, birdExporterEnabled bool, multusEnabled bool, installCNIPlugins bool,
 			modeFunc func() string, detectionMethodFunc func() *string, nodesFunc func() *string, additionalGlobalOptions map[string]string) {
-			values, err := ComputeCalicoChartValues(network, config(), kubernetesVersion, wantsVPA, kubeProxyEnabled, false, nodesFunc(), []string{network.Spec.PodCIDR}, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4})
+			values, err := ComputeCalicoChartValues(network, config(), kubernetesVersion, wantsVPA, kubeProxyEnabled, nil, false, nodesFunc(), []string{network.Spec.PodCIDR}, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4})
 			Expect(err).To(BeNil())
 			expected := map[string]interface{}{
 				"images": map[string]interface{}{
@@ -418,7 +418,7 @@ var _ = Describe("Chart package test", func() {
 		var podCIDR = "12.0.0.0/8"
 		DescribeTable("should correctly compute calico chart values with non-privileged mode enabled",
 			func(config func() *calicov1alpha1.NetworkConfig, expectedResult bool) {
-				values, err := ComputeCalicoChartValues(network, config(), kubernetesVersion, true, true, true, &nodeCIDR, nil, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4})
+				values, err := ComputeCalicoChartValues(network, config(), kubernetesVersion, true, true, nil, true, &nodeCIDR, nil, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4})
 				Expect(err).To(BeNil())
 
 				actual, err := utils.GetFromValuesMap(values, "config", "nonPrivileged")
@@ -431,7 +431,7 @@ var _ = Describe("Chart package test", func() {
 		)
 
 		It("should error on invalid config value", func() {
-			_, err := ComputeCalicoChartValues(network, networkConfigInvalid, kubernetesVersion, true, true, false, &nodeCIDR, nil, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4})
+			_, err := ComputeCalicoChartValues(network, networkConfigInvalid, kubernetesVersion, true, true, nil, false, &nodeCIDR, nil, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4})
 			Expect(err).To(Equal(fmt.Errorf("error when generating calico config: unsupported value for backend: invalid")))
 		})
 
@@ -449,7 +449,7 @@ var _ = Describe("Chart package test", func() {
 			It("should correctly configure for IPv4 networks", func() {
 				values, err := ComputeCalicoChartValues(
 					network,
-					nil, "", false, false, false, nil, nil, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4},
+					nil, "", false, false, nil, false, nil, nil, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4},
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -486,7 +486,7 @@ var _ = Describe("Chart package test", func() {
 				}
 				values, err := ComputeCalicoChartValues(
 					network, config,
-					"", false, false, false, nil, nil, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4},
+					"", false, false, nil, false, nil, nil, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4},
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -519,7 +519,7 @@ var _ = Describe("Chart package test", func() {
 				}
 				values, err := ComputeCalicoChartValues(
 					network, config,
-					"", false, false, false, nil, nil, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4},
+					"", false, false, nil, false, nil, nil, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4},
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -560,7 +560,7 @@ var _ = Describe("Chart package test", func() {
 			It("should correctly configure for IPv6 networks", func() {
 				values, err := ComputeCalicoChartValues(
 					network,
-					nil, "", false, false, false, nil, []string{"2001:0db8:85a3:0000::/56"}, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv6},
+					nil, "", false, false, nil, false, nil, []string{"2001:0db8:85a3:0000::/56"}, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv6},
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -598,7 +598,7 @@ var _ = Describe("Chart package test", func() {
 				}
 				values, err := ComputeCalicoChartValues(
 					network, config,
-					"", false, false, false, nil, []string{"2001:0db8:85a3:0000::/56"}, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv6},
+					"", false, false, nil, false, nil, []string{"2001:0db8:85a3:0000::/56"}, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv6},
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -642,7 +642,7 @@ var _ = Describe("Chart package test", func() {
 			It("should correctly configure for Dual-stack networks", func() {
 				values, err := ComputeCalicoChartValues(
 					network,
-					nil, "", false, false, false, nil, []string{"2001:0db8:85a3:0000::/56", podCIDR}, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4, extensionsv1alpha1.IPFamilyIPv6},
+					nil, "", false, false, nil, false, nil, []string{"2001:0db8:85a3:0000::/56", podCIDR}, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4, extensionsv1alpha1.IPFamilyIPv6},
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -698,7 +698,7 @@ var _ = Describe("Chart package test", func() {
 					},
 				}, nil)
 
-				_, err := RenderCalicoChart(mockChartRenderer, network, networkConfigNil, kubernetesVersion, false, true, false, nodes, nil, nil)
+				_, err := RenderCalicoChart(mockChartRenderer, network, networkConfigNil, kubernetesVersion, false, true, nil, false, nodes, nil, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 			},

--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 
+	corev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	mockchartrenderer "github.com/gardener/gardener/pkg/chartrenderer/mock"
@@ -241,10 +242,11 @@ var _ = Describe("Chart package test", func() {
 
 	DescribeTable("#ComputeCalicoChartValues",
 		func(config func() *calicov1alpha1.NetworkConfig, configResult func() *calicov1alpha1.NetworkConfig, typhaEnabled bool, wantsVPA bool,
-			kubeProxyEnabled bool, mtu string, ipinip bool, bpf bool, pool string, birdExporterEnabled bool, multusEnabled bool, installCNIPlugins bool,
+			kubeProxyEnabled bool, mtu string, ipinip bool, bpf bool, kubeProxyMode *corev1beta1.ProxyMode, pool string, birdExporterEnabled bool, multusEnabled bool, installCNIPlugins bool,
 			modeFunc func() string, detectionMethodFunc func() *string, nodesFunc func() *string, additionalGlobalOptions map[string]string) {
-			values, err := ComputeCalicoChartValues(network, config(), kubernetesVersion, wantsVPA, kubeProxyEnabled, nil, false, nodesFunc(), []string{network.Spec.PodCIDR}, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4})
+			values, err := ComputeCalicoChartValues(network, config(), kubernetesVersion, wantsVPA, kubeProxyEnabled, kubeProxyMode, false, nodesFunc(), []string{network.Spec.PodCIDR}, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4})
 			Expect(err).To(BeNil())
+
 			expected := map[string]interface{}{
 				"images": map[string]interface{}{
 					"calico-cni":              imagevector.CalicoCNIImage(kubernetesVersion),
@@ -296,6 +298,9 @@ var _ = Describe("Chart package test", func() {
 						"bpfKubeProxyIPTablesCleanup": map[string]interface{}{
 							"enabled": !kubeProxyEnabled,
 						},
+						"nftables": map[string]interface{}{
+							"enabled": kubeProxyMode != nil && *kubeProxyMode == corev1beta1.ProxyModeNFTables,
+						},
 					},
 					"ipv4": map[string]interface{}{
 						"enabled":             true,
@@ -344,72 +349,77 @@ var _ = Describe("Chart package test", func() {
 
 		Entry("empty network config should properly render calico chart values",
 			networkConfigNilFunc, networkConfigNilValuesFunc,
-			true, false, true, defaultMtu, true, false, string(poolIPIP), false, false, false,
+			true, false, true, defaultMtu, true, false, pointer(corev1beta1.ProxyModeIPTables), string(poolIPIP), false, false, false,
 			func() string { return string(always) }, func() *string { return nil },
 			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR}),
 		Entry("empty network config should properly render calico chart values even without node cidr",
 			networkConfigNilFunc, networkConfigNilValuesFunc,
-			true, false, true, defaultMtu, true, false, string(poolIPIP), false, false, false,
+			true, false, true, defaultMtu, true, false, pointer(corev1beta1.ProxyModeIPTables), string(poolIPIP), false, false, false,
 			func() string { return string(always) }, func() *string { return nil },
 			func() *string { return nil }, nil),
 		Entry("should disable felix ip in ip and set pool mode to never when setting backend to none",
 			networkConfigBackendNoneFunc, networkConfigBackendNoneFunc,
-			true, false, true, defaultMtu, false, false, string(poolIPIP), false, false, false,
+			true, false, true, defaultMtu, false, false, pointer(corev1beta1.ProxyModeIPTables), string(poolIPIP), false, false, false,
 			func() string { return string(never) }, func() *string { return nil },
 			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR}),
 		Entry("should correctly compute all of the calico chart values",
 			networkConfigAllFunc, networkConfigAllFunc,
-			true, true, true, defaultMtu, true, false, string(poolVXlan), false, false, false,
+			true, true, true, defaultMtu, true, false, pointer(corev1beta1.ProxyModeIPTables), string(poolVXlan), false, false, false,
 			func() string { return string(*networkConfigAll.IPv4.Mode) }, func() *string { return networkConfigAll.IPv4.AutoDetectionMethod },
 			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR}),
 		Entry("should correctly compute all of the calico chart values with mtu",
 			networkConfigAllMTUFunc, networkConfigAllMTUFunc,
-			true, false, true, mtuVar, true, false, string(poolVXlan), false, false, false,
+			true, false, true, mtuVar, true, false, pointer(corev1beta1.ProxyModeIPTables), string(poolVXlan), false, false, false,
 			func() string { return string(*networkConfigAll.IPv4.Mode) }, func() *string { return networkConfigAll.IPv4.AutoDetectionMethod },
 			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR}),
 		Entry("should correctly compute all of the calico chart values with serviceLoopPrevention",
 			networkConfigAllFelixFunc, networkConfigAllFelixFunc,
-			true, true, true, defaultMtu, true, false, string(poolVXlan), false, false, false,
+			true, true, true, defaultMtu, true, false, pointer(corev1beta1.ProxyModeIPTables), string(poolVXlan), false, false, false,
 			func() string { return string(*networkConfigAll.IPv4.Mode) }, func() *string { return networkConfigAll.IPv4.AutoDetectionMethod },
 			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR}),
 		Entry("should correctly compute all of the calico chart values with ebpf dataplane enabled and kube-proxy disabled",
 			networkConfigAllEBPFDataplaneFunc, networkConfigAllEBPFDataplaneFunc,
-			true, false, false, defaultMtu, true, true, string(poolVXlan), false, false, false,
+			true, false, false, defaultMtu, true, true, nil, string(poolVXlan), false, false, false,
 			func() string { return string(*networkConfigAll.IPv4.Mode) }, func() *string { return networkConfigAll.IPv4.AutoDetectionMethod },
 			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR}),
 		Entry("should correctly compute all of the calico chart values with overlay disabled",
 			networkConfigOverlayDisabledFunc, networkConfigOverlayDisabledFunc,
-			true, true, true, defaultMtu, false, false, string(poolIPIP), false, false, false,
+			true, true, true, defaultMtu, false, false, pointer(corev1beta1.ProxyModeIPTables), string(poolIPIP), false, false, false,
 			func() string { return string(*networkConfigOverlayDisabled.IPv4.Mode) }, func() *string { return networkConfigOverlayDisabled.IPv4.AutoDetectionMethod },
 			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR, "overlayEnabled": "false", "snatToUpstreamDNSEnabled": "true"}),
 		Entry("should correctly compute all of the calico chart values with overlay disabled, but no node cidr",
 			networkConfigOverlayDisabledFunc, networkConfigOverlayDisabledFunc,
-			true, true, true, defaultMtu, false, false, string(poolIPIP), false, false, false,
+			true, true, true, defaultMtu, false, false, pointer(corev1beta1.ProxyModeIPTables), string(poolIPIP), false, false, false,
 			func() string { return string(*networkConfigOverlayDisabled.IPv4.Mode) }, func() *string { return networkConfigOverlayDisabled.IPv4.AutoDetectionMethod },
 			func() *string { return nil }, map[string]string{"overlayEnabled": "false", "snatToUpstreamDNSEnabled": "true"}),
 		Entry("should respect deprecated fields in order to keep backwards compatibility",
 			networkConfigDeprecatedFunc, networkConfigDeprecatedFunc,
-			true, true, true, defaultMtu, true, false, string(poolIPIP), false, false, false,
+			true, true, true, defaultMtu, true, false, pointer(corev1beta1.ProxyModeIPTables), string(poolIPIP), false, false, false,
 			func() string { return string(*networkConfigDeprecated.IPIP) }, func() *string { return networkConfigDeprecated.IPAutoDetectionMethod },
 			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR}),
 		Entry("should correctly compute all of the calico chart values with wireguard enabled",
 			networkConfigWireguardFunc, networkConfigWireguardFunc,
-			true, false, true, defaultMtu, true, false, string(poolIPIP), false, false, false,
+			true, false, true, defaultMtu, true, false, pointer(corev1beta1.ProxyModeIPTables), string(poolIPIP), false, false, false,
 			func() string { return string(always) }, func() *string { return nil },
 			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR}),
 		Entry("should correctly compute all of the calico chart values with bird-exporter enabled",
 			networkConfigBirdExporterFunc, networkConfigBirdExporterFunc,
-			true, false, true, defaultMtu, true, false, string(poolIPIP), true, false, false,
+			true, false, true, defaultMtu, true, false, pointer(corev1beta1.ProxyModeIPTables), string(poolIPIP), true, false, false,
 			func() string { return string(always) }, func() *string { return nil },
 			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR}),
 		Entry("should correctly compute all of the calico chart values with multus enabled",
 			networkConfigMultusFunc, networkConfigMultusFunc,
-			true, false, true, defaultMtu, true, false, string(poolIPIP), false, true, true,
+			true, false, true, defaultMtu, true, false, pointer(corev1beta1.ProxyModeIPTables), string(poolIPIP), false, true, true,
 			func() string { return string(always) }, func() *string { return nil },
 			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR}),
 		Entry("should not create VPA config for typha when typha is disabled",
 			networkConfigVPATyphaDisabledFunc, networkConfigVPATyphaDisabledFunc,
-			false, true, true, defaultMtu, true, false, string(poolIPIP), false, false, false,
+			false, true, true, defaultMtu, true, false, pointer(corev1beta1.ProxyModeIPTables), string(poolIPIP), false, false, false,
+			func() string { return string(always) }, func() *string { return nil },
+			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR}),
+		Entry("should set nftables to enabled if kube-proxy mode is nftables",
+			networkConfigNilFunc, networkConfigNilValuesFunc,
+			true, false, true, defaultMtu, true, false, pointer(corev1beta1.ProxyModeNFTables), string(poolIPIP), false, false, false,
 			func() string { return string(always) }, func() *string { return nil },
 			func() *string { return &nodeCIDR }, map[string]string{"nodeCIDR": nodeCIDR}),
 	)
@@ -670,6 +680,62 @@ var _ = Describe("Chart package test", func() {
 					HaveKeyWithValue("podCIDR", podCIDR),
 					HaveKeyWithValue("podCIDRv6", "2001:0db8:85a3:0000::/56"),
 				))
+			})
+		})
+		Context("nftables", func() {
+			BeforeEach(func() {
+				network = &extensionsv1alpha1.Network{}
+			})
+			It("should not enable nftables if kube-proxy is in iptables mode", func() {
+				enablekubeproxy := true
+				kubeproxymode := corev1beta1.ProxyModeIPTables
+				values, err := ComputeCalicoChartValues(network, nil, kubernetesVersion, false, enablekubeproxy, &kubeproxymode, false, nil, nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(values["config"]).To(
+					HaveKeyWithValue("felix", And(
+						HaveKeyWithValue("bpf", HaveKeyWithValue("enabled", false)),
+						HaveKeyWithValue("bpfKubeProxyIPTablesCleanup", HaveKeyWithValue("enabled", false)),
+						HaveKeyWithValue("nftables", HaveKeyWithValue("enabled", false)),
+					)),
+				)
+			})
+
+			It("should not enable nftables if kube-proxy is in ipvs mode", func() {
+				enablekubeproxy := true
+				kubeproxymode := corev1beta1.ProxyModeIPVS
+				values, err := ComputeCalicoChartValues(network, nil, kubernetesVersion, false, enablekubeproxy, &kubeproxymode, false, nil, nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(values["config"]).To(
+					HaveKeyWithValue("felix", And(
+						HaveKeyWithValue("bpf", HaveKeyWithValue("enabled", false)),
+						HaveKeyWithValue("bpfKubeProxyIPTablesCleanup", HaveKeyWithValue("enabled", false)),
+						HaveKeyWithValue("nftables", HaveKeyWithValue("enabled", false)),
+					)),
+				)
+			})
+
+			It("should enable nftables if kube-proxy is in nftables mode", func() {
+				enablekubeproxy := true
+				kubeproxymode := corev1beta1.ProxyModeNFTables
+				values, err := ComputeCalicoChartValues(network, nil, kubernetesVersion, false, enablekubeproxy, &kubeproxymode, false, nil, nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(values["config"]).To(
+					HaveKeyWithValue("felix", And(
+						HaveKeyWithValue("bpf", HaveKeyWithValue("enabled", false)),
+						HaveKeyWithValue("bpfKubeProxyIPTablesCleanup", HaveKeyWithValue("enabled", false)),
+						HaveKeyWithValue("nftables", HaveKeyWithValue("enabled", true)),
+					)),
+				)
+			})
+
+			It("should error out if kubeProxyMode is set but kube-proxy is not enabled", func() {
+				enablekubeproxy := false
+				kubeproxymode := corev1beta1.ProxyModeNFTables
+				_, err := ComputeCalicoChartValues(network, nil, kubernetesVersion, false, enablekubeproxy, &kubeproxymode, false, nil, nil, nil)
+				Expect(err).To(HaveOccurred())
 			})
 		})
 	})

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -45,8 +45,8 @@ type felix struct {
 	IPInIP                      felixIPinIP                           `json:"ipinip"`
 	BPF                         felixBPF                              `json:"bpf"`
 	BPFKubeProxyIptablesCleanup felixBPFKubeProxyIptablesCleanup      `json:"bpfKubeProxyIPTablesCleanup"`
-	ServiceLoopPrevention       *calicov1alpha1.ServiceLoopPrevention `json:"serviceLoopPrevention,omitempty"`
 	NFTables                    felixNFTables                         `json:"nftables"`
+	ServiceLoopPrevention       *calicov1alpha1.ServiceLoopPrevention `json:"serviceLoopPrevention,omitempty"`
 }
 
 type felixIPinIP struct {
@@ -131,6 +131,9 @@ var defaultCalicoConfig = calicoConfig{
 			Enabled: false,
 		},
 		BPFKubeProxyIptablesCleanup: felixBPFKubeProxyIptablesCleanup{
+			Enabled: false,
+		},
+		NFTables: felixNFTables{
 			Enabled: false,
 		},
 	},
@@ -302,13 +305,16 @@ func generateChartValues(network *extensionsv1alpha1.Network, config *calicov1al
 		)
 	}
 
-	if kubeProxyMode != nil {
+	if kubeProxyEnabled && kubeProxyMode != nil {
 		if *kubeProxyMode == v1beta1.ProxyModeNFTables {
 			c.Felix.NFTables.Enabled = true
 		}
 	}
 
 	if !kubeProxyEnabled {
+		if kubeProxyMode != nil {
+			return nil, fmt.Errorf("kube-proxy mode must not be set if kube-proxy is disabled")
+		}
 		c.Felix.BPFKubeProxyIptablesCleanup.Enabled = true
 	}
 

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 
@@ -45,6 +46,7 @@ type felix struct {
 	BPF                         felixBPF                              `json:"bpf"`
 	BPFKubeProxyIptablesCleanup felixBPFKubeProxyIptablesCleanup      `json:"bpfKubeProxyIPTablesCleanup"`
 	ServiceLoopPrevention       *calicov1alpha1.ServiceLoopPrevention `json:"serviceLoopPrevention,omitempty"`
+	NFTables                    felixNFTables                         `json:"nftables"`
 }
 
 type felixIPinIP struct {
@@ -56,6 +58,10 @@ type felixBPF struct {
 }
 
 type felixBPFKubeProxyIptablesCleanup struct {
+	Enabled bool `json:"enabled"`
+}
+
+type felixNFTables struct {
 	Enabled bool `json:"enabled"`
 }
 
@@ -179,12 +185,13 @@ func ComputeCalicoChartValues(
 	kubernetesVersion string,
 	wantsVPA bool,
 	kubeProxyEnabled bool,
+	kubeProxyMode *v1beta1.ProxyMode,
 	nonPrivileged bool,
 	nodeCIDR *string,
 	podCIDRs []string,
 	ipFamilies []extensionsv1alpha1.IPFamily,
 ) (map[string]interface{}, error) {
-	typedConfig, err := generateChartValues(network, config, kubeProxyEnabled, nonPrivileged, ipFamilies)
+	typedConfig, err := generateChartValues(network, config, kubeProxyEnabled, kubeProxyMode, nonPrivileged, ipFamilies)
 	if err != nil {
 		return nil, fmt.Errorf("error when generating calico config: %v", err)
 	}
@@ -256,7 +263,7 @@ func ComputeCalicoChartValues(
 	return calicoChartValues, nil
 }
 
-func generateChartValues(network *extensionsv1alpha1.Network, config *calicov1alpha1.NetworkConfig, kubeProxyEnabled bool, nonPrivileged bool, ipFamilies []extensionsv1alpha1.IPFamily) (*calicoConfig, error) {
+func generateChartValues(network *extensionsv1alpha1.Network, config *calicov1alpha1.NetworkConfig, kubeProxyEnabled bool, kubeProxyMode *v1beta1.ProxyMode, nonPrivileged bool, ipFamilies []extensionsv1alpha1.IPFamily) (*calicoConfig, error) {
 	isIPv4 := slices.Contains(ipFamilies, extensionsv1alpha1.IPFamilyIPv4)
 	isIPv6 := slices.Contains(ipFamilies, extensionsv1alpha1.IPFamilyIPv6)
 
@@ -293,6 +300,12 @@ func generateChartValues(network *extensionsv1alpha1.Network, config *calicov1al
 			[]ipamRange{{Subnet: usePodCIDRv6}},
 			[]ipamRange{{Subnet: usePodCIDR}},
 		)
+	}
+
+	if kubeProxyMode != nil {
+		if *kubeProxyMode == v1beta1.ProxyModeNFTables {
+			c.Felix.NFTables.Enabled = true
+		}
 	}
 
 	if !kubeProxyEnabled {

--- a/pkg/charts/values.go
+++ b/pkg/charts/values.go
@@ -5,6 +5,7 @@
 package charts
 
 import (
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,12 +25,13 @@ func RenderCalicoChart(
 	kubernetesVersion string,
 	wantsVPA bool,
 	kubeProxyEnabled bool,
+	kubeProxyMode *v1beta1.ProxyMode,
 	nonPrivileged bool,
 	nodeCIDR *string,
 	podCidrs []string,
 	ipFamilies []extensionsv1alpha1.IPFamily,
 ) ([]byte, error) {
-	values, err := ComputeCalicoChartValues(network, config, kubernetesVersion, wantsVPA, kubeProxyEnabled, nonPrivileged, nodeCIDR, podCidrs, ipFamilies)
+	values, err := ComputeCalicoChartValues(network, config, kubernetesVersion, wantsVPA, kubeProxyEnabled, kubeProxyMode, nonPrivileged, nodeCIDR, podCidrs, ipFamilies)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -222,8 +222,12 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, network *exte
 	}
 
 	kubeProxyEnabled := true
-	if cluster.Shoot.Spec.Kubernetes.KubeProxy != nil && cluster.Shoot.Spec.Kubernetes.KubeProxy.Enabled != nil {
-		kubeProxyEnabled = *cluster.Shoot.Spec.Kubernetes.KubeProxy.Enabled
+	var kubeProxyMode *v1beta1.ProxyMode
+	if cluster.Shoot.Spec.Kubernetes.KubeProxy != nil {
+		if cluster.Shoot.Spec.Kubernetes.KubeProxy.Enabled != nil {
+			kubeProxyEnabled = *cluster.Shoot.Spec.Kubernetes.KubeProxy.Enabled
+		}
+		kubeProxyMode = cluster.Shoot.Spec.Kubernetes.KubeProxy.Mode
 	}
 
 	// Create shoot chart renderer
@@ -244,6 +248,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, network *exte
 		cluster.Shoot.Spec.Kubernetes.Version,
 		gardencorev1beta1helper.ShootWantsVerticalPodAutoscaler(cluster.Shoot),
 		kubeProxyEnabled,
+		kubeProxyMode,
 		features.FeatureGate.Enabled(features.NonPrivilegedCalicoNode),
 		cluster.Shoot.Spec.Networking.Nodes,
 		podCIDRs,


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Propagate kube-proxy mode to Felix configuration. Allows to run Calico in the same mode as kube-proxy does.

**Which issue(s) this PR fixes**:
Fixes #800

**Special notes for your reviewer**:
/cc @mstueer

The current image used (v3.30.7) does not yet included the cleanup fix: <https://github.com/projectcalico/calico/pull/10530>
It's only backported to v3.31. What's the plan on upgrading to this version?

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
Support Calico NFTables mode
```
