### PR TITLE
Use the correct API version for MutatingAdmissionPolicy

### DIFF
--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -66,7 +66,46 @@ providerConfig:
         SeamlessOverlaySwitch: true
 ```
 
-Note: Seamless overlay switching requires the shoot Kubernetes cluster to be running Kubernetes >= 1.36 or to have the MutatingAdmissionPolicy admission feature enabled in the kube-apiserver (feature gate and RuntimeConfig). Without one of these, the extension cannot use the newer admission APIs needed for the seamless switch.
+##### Kubernetes version requirements
+
+The seamless overlay switch relies on the `MutatingAdmissionPolicy` admission API. The availability of this API depends on the shoot's Kubernetes version:
+
+| Kubernetes version | MutatingAdmissionPolicy state | What you need to do |
+|--------------------|-------------------------------|---------------------|
+| < 1.34             | Alpha (off by default)        | Explicitly enable via feature gate and runtimeConfig (see below) |
+| >= 1.34, < 1.36    | Beta (on by default)          | Nothing — seamless switch activates automatically unless you explicitly disable it |
+| >= 1.36            | GA (always on)                | Nothing — seamless switch activates automatically |
+
+**Migrating from Kubernetes 1.33 → 1.34**
+
+On Kubernetes 1.33 (alpha), the feature is off by default. To use the seamless overlay switch while still on 1.33, or to ensure the admission webhook is available when upgrading to 1.34, explicitly enable `MutatingAdmissionPolicy` in the shoot spec:
+
+```yaml
+spec:
+  kubernetes:
+    version: 1.34.3
+    kubeAPIServer:
+      featureGates:
+        MutatingAdmissionPolicy: true
+      runtimeConfig:
+        admissionregistration.k8s.io/v1alpha1: true
+        admissionregistration.k8s.io/v1beta1: true
+```
+
+Both `v1alpha1` and `v1beta1` runtimeConfig entries are required because 1.33 serves the API under `v1alpha1`, while 1.34 promotes it to `v1beta1`. Enabling both ensures a smooth transition across the upgrade.
+
+**Migrating from Kubernetes 1.35 → 1.36**
+
+On 1.35 (beta) the feature is already on by default, so no extra configuration is needed. The seamless overlay switch activates automatically. If for any reason `MutatingAdmissionPolicy` was explicitly disabled on 1.35, remove that override before or during the upgrade to 1.36, where it becomes GA and can no longer be disabled:
+
+```yaml
+spec:
+  kubernetes:
+    version: 1.36.0
+    kubeAPIServer:
+      featureGates:
+        # Remove or omit any prior: MutatingAdmissionPolicy: false
+```
 
 ##### Behavior
 

--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -72,13 +72,13 @@ The seamless overlay switch relies on the `MutatingAdmissionPolicy` admission AP
 
 | Kubernetes version | MutatingAdmissionPolicy state | What you need to do |
 |--------------------|-------------------------------|---------------------|
-| < 1.34             | Alpha (off by default)        | Explicitly enable via feature gate and runtimeConfig (see below) |
-| >= 1.34, < 1.36    | Beta (on by default)          | Nothing — seamless switch activates automatically unless you explicitly disable it |
-| >= 1.36            | GA (always on)                | Nothing — seamless switch activates automatically |
+| < 1.34             | Alpha (off by default)                                                                                              | Explicitly enable via feature gate and runtimeConfig (see below) |
+| >= 1.34, < 1.36    | Beta, but [off by default per KEP-3136](https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/3136-beta-apis-off-by-default) | Explicitly enable via feature gate and runtimeConfig (see below) |
+| >= 1.36            | GA (always on)                                                                                                      | Nothing — seamless switch activates automatically |
 
-**Migrating from Kubernetes 1.33 → 1.34**
+**Enabling MutatingAdmissionPolicy on Kubernetes < 1.36**
 
-On Kubernetes 1.33 (alpha), the feature is off by default. To use the seamless overlay switch while still on 1.33, or to ensure the admission webhook is available when upgrading to 1.34, explicitly enable `MutatingAdmissionPolicy` in the shoot spec:
+For shoots on 1.33 (alpha) or 1.34 / 1.35 (beta, off by default per KEP-3136), the feature must be opted in explicitly. Set the feature gate and the matching `runtimeConfig` entry in the shoot spec:
 
 ```yaml
 spec:
@@ -92,11 +92,11 @@ spec:
         admissionregistration.k8s.io/v1beta1: true
 ```
 
-Both `v1alpha1` and `v1beta1` runtimeConfig entries are required because 1.33 serves the API under `v1alpha1`, while 1.34 promotes it to `v1beta1`. Enabling both ensures a smooth transition across the upgrade.
+The API is served under `v1alpha1` on 1.33 and promoted to `v1beta1` on 1.34. Enabling both runtimeConfig entries keeps the configuration valid across upgrades between these versions.
 
 **Migrating from Kubernetes 1.35 → 1.36**
 
-On 1.35 (beta) the feature is already on by default, so no extra configuration is needed. The seamless overlay switch activates automatically. If for any reason `MutatingAdmissionPolicy` was explicitly disabled on 1.35, remove that override before or during the upgrade to 1.36, where it becomes GA and can no longer be disabled:
+On 1.36 the feature graduates to GA and is locked on, so the explicit feature gate and `runtimeConfig` entries are no longer required (and `MutatingAdmissionPolicy: false` is rejected). Remove any explicit overrides before or during the upgrade:
 
 ```yaml
 spec:
@@ -104,7 +104,7 @@ spec:
     version: 1.36.0
     kubeAPIServer:
       featureGates:
-        # Remove or omit any prior: MutatingAdmissionPolicy: false
+        # Remove or omit any prior MutatingAdmissionPolicy setting
 ```
 
 ##### Behavior

--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -179,12 +179,17 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, network *exte
 		return fmt.Errorf("failed to parse shoot Kubernetes version %s: %w", cluster.Shoot.Spec.Kubernetes.Version, err)
 	}
 
-	newK8sGreaterEqual136, err := versionutils.CheckVersionMeetsConstraint(shootKubernetesVersion.String(), ">= 1.36")
+	newK8sGreaterEqual134, err := versionutils.CheckVersionMeetsConstraint(shootKubernetesVersion.String(), ">= 1.34")
 	if err != nil {
 		return fmt.Errorf("failed to check version constraint %w", err)
 	}
 
-	if features.FeatureGate.Enabled(features.SeamlessOverlaySwitch) && (newK8sGreaterEqual136 || isMutatingAdmissionPolicyEnabled(cluster)) {
+	// For K8s >= 1.34, MutatingAdmissionPolicy is beta (enabled by default).
+	// Users can still explicitly disable it via feature gate until GA (>= 1.36).
+	mutatingAdmissionPolicyAvailable := newK8sGreaterEqual134 && !isMutatingAdmissionPolicyExplicitlyDisabled(cluster) ||
+		isMutatingAdmissionPolicyEnabled(cluster)
+
+	if features.FeatureGate.Enabled(features.SeamlessOverlaySwitch) && mutatingAdmissionPolicyAvailable {
 		overlaySwitch, err := isOverlaySwitch(ctx, log, a.client, network)
 		if err != nil {
 			return fmt.Errorf("failed to detect pod overlay switch: %w", err)
@@ -456,6 +461,19 @@ func getDaemonSetFromManagedResource(ctx context.Context, c client.Client, names
 	}
 
 	return nil, fmt.Errorf("DaemonSet %q not found in ManagedResource %q", daemonSetName, mrName)
+}
+
+// isMutatingAdmissionPolicyExplicitlyDisabled returns true if the user has explicitly
+// set the MutatingAdmissionPolicy feature gate to false. This is relevant for
+// K8s >= 1.34 and < 1.36 where the feature is beta (on by default) but can be disabled.
+func isMutatingAdmissionPolicyExplicitlyDisabled(cluster *extensionscontroller.Cluster) bool {
+	if cluster.Shoot.Spec.Kubernetes.KubeAPIServer != nil &&
+		cluster.Shoot.Spec.Kubernetes.KubeAPIServer.FeatureGates != nil {
+		if enabled, ok := cluster.Shoot.Spec.Kubernetes.KubeAPIServer.FeatureGates["MutatingAdmissionPolicy"]; ok && !enabled {
+			return true
+		}
+	}
+	return false
 }
 
 func isMutatingAdmissionPolicyEnabled(cluster *extensionscontroller.Cluster) bool {

--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -179,15 +179,16 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, network *exte
 		return fmt.Errorf("failed to parse shoot Kubernetes version %s: %w", cluster.Shoot.Spec.Kubernetes.Version, err)
 	}
 
-	newK8sGreaterEqual134, err := versionutils.CheckVersionMeetsConstraint(shootKubernetesVersion.String(), ">= 1.34")
+	newK8sGreaterEqual136, err := versionutils.CheckVersionMeetsConstraint(shootKubernetesVersion.String(), ">= 1.36")
 	if err != nil {
 		return fmt.Errorf("failed to check version constraint %w", err)
 	}
 
-	// For K8s >= 1.34, MutatingAdmissionPolicy is beta (enabled by default).
-	// Users can still explicitly disable it via feature gate until GA (>= 1.36).
-	mutatingAdmissionPolicyAvailable := newK8sGreaterEqual134 && !isMutatingAdmissionPolicyExplicitlyDisabled(cluster) ||
-		isMutatingAdmissionPolicyEnabled(cluster)
+	// MutatingAdmissionPolicy is GA (always on) starting with K8s 1.36. For earlier
+	// versions it is alpha (< 1.34) or beta (>= 1.34, < 1.36). Per KEP-3136 beta APIs
+	// are off by default, so 1.34 and 1.35 still require an explicit opt-in via the
+	// MutatingAdmissionPolicy feature gate plus a matching runtimeConfig entry.
+	mutatingAdmissionPolicyAvailable := newK8sGreaterEqual136 || isMutatingAdmissionPolicyEnabled(cluster)
 
 	if features.FeatureGate.Enabled(features.SeamlessOverlaySwitch) && mutatingAdmissionPolicyAvailable {
 		overlaySwitch, err := isOverlaySwitch(ctx, log, a.client, network)
@@ -461,19 +462,6 @@ func getDaemonSetFromManagedResource(ctx context.Context, c client.Client, names
 	}
 
 	return nil, fmt.Errorf("DaemonSet %q not found in ManagedResource %q", daemonSetName, mrName)
-}
-
-// isMutatingAdmissionPolicyExplicitlyDisabled returns true if the user has explicitly
-// set the MutatingAdmissionPolicy feature gate to false. This is relevant for
-// K8s >= 1.34 and < 1.36 where the feature is beta (on by default) but can be disabled.
-func isMutatingAdmissionPolicyExplicitlyDisabled(cluster *extensionscontroller.Cluster) bool {
-	if cluster.Shoot.Spec.Kubernetes.KubeAPIServer != nil &&
-		cluster.Shoot.Spec.Kubernetes.KubeAPIServer.FeatureGates != nil {
-		if enabled, ok := cluster.Shoot.Spec.Kubernetes.KubeAPIServer.FeatureGates["MutatingAdmissionPolicy"]; ok && !enabled {
-			return true
-		}
-	}
-	return false
 }
 
 func isMutatingAdmissionPolicyEnabled(cluster *extensionscontroller.Cluster) bool {


### PR DESCRIPTION
**How to categorize this PR?**
/area networking
/kind enhancement

**What this PR does / why we need it**:

`MutatingAdmissionPolicy` graduates from `v1alpha1` → `v1beta1` in Kubernetes 1.34 and to `v1` (GA) in 1.36. The seamless overlay switch in this extension relies on that admission API, so the activation logic has to follow the API's availability across versions.

Per [KEP-3136](https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/3136-beta-apis-off-by-default), beta APIs are off by default — so 1.34 and 1.35 still require an explicit opt-in even though the feature is in beta. This PR aligns the activation logic accordingly:

- `< 1.34`: alpha, requires explicit feature gate + `runtimeConfig` opt-in
- `>= 1.34` and `< 1.36`: beta but disabled by default per KEP-3136 — requires explicit feature gate + `runtimeConfig` opt-in
- `>= 1.36`: GA, always enabled (feature gate locked on) — seamless switch activates automatically

Operator docs are updated to reflect the per-version requirements and the migration steps across 1.33 → 1.34 and 1.35 → 1.36.

Mirrors the equivalent provider PRs:
- gardener/gardener-extension-provider-aws#1770 (initial change) and gardener/gardener-extension-provider-aws#1800 (KEP-3136 hotfix)
- gardener/gardener-extension-provider-gcp#1428
- gardener/gardener-extension-provider-openstack#1366

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other operator
Seamless overlay switch activation is aligned with the `MutatingAdmissionPolicy` admission API availability across Kubernetes versions: `>= 1.36` (GA) activates automatically, `< 1.36` (alpha or beta, off by default per KEP-3136) requires explicit feature gate + `runtimeConfig` opt-in.
```