### PR TITLE
Disable IP-in-IP when overlay is switched off

### DIFF
--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -50,35 +50,37 @@ var _ = Describe("Chart package test", func() {
 		poolVXlan                                                  = calicov1alpha1.PoolVXLan
 		felixServiceLoopPreventionDisabled                         = calicov1alpha1.ServiceLoopPreventionDisabled
 
-		network                       *extensionsv1alpha1.Network
-		networkConfigNil              *calicov1alpha1.NetworkConfig
-		networkConfigNilValues        *calicov1alpha1.NetworkConfig
-		networkConfigBackendNone      *calicov1alpha1.NetworkConfig
-		networkConfigAll              *calicov1alpha1.NetworkConfig
-		networkConfigAllFelix         *calicov1alpha1.NetworkConfig
-		networkConfigAllMTU           *calicov1alpha1.NetworkConfig
-		networkConfigAllEBPFDataplane *calicov1alpha1.NetworkConfig
-		networkConfigDeprecated       *calicov1alpha1.NetworkConfig
-		networkConfigInvalid          *calicov1alpha1.NetworkConfig
-		networkConfigOverlayDisabled  *calicov1alpha1.NetworkConfig
-		networkConfigWireguard        *calicov1alpha1.NetworkConfig
-		networkConfigBirdExporter     *calicov1alpha1.NetworkConfig
-		networkConfigMultus           *calicov1alpha1.NetworkConfig
-		networkConfigVPATyphaDisabled *calicov1alpha1.NetworkConfig
+		network                          *extensionsv1alpha1.Network
+		networkConfigNil                 *calicov1alpha1.NetworkConfig
+		networkConfigNilValues           *calicov1alpha1.NetworkConfig
+		networkConfigBackendNone         *calicov1alpha1.NetworkConfig
+		networkConfigAll                 *calicov1alpha1.NetworkConfig
+		networkConfigAllFelix            *calicov1alpha1.NetworkConfig
+		networkConfigAllMTU              *calicov1alpha1.NetworkConfig
+		networkConfigAllEBPFDataplane    *calicov1alpha1.NetworkConfig
+		networkConfigDeprecated          *calicov1alpha1.NetworkConfig
+		networkConfigInvalid             *calicov1alpha1.NetworkConfig
+		networkConfigOverlayDisabled     *calicov1alpha1.NetworkConfig
+		networkConfigOverlayDisabledBird *calicov1alpha1.NetworkConfig
+		networkConfigWireguard           *calicov1alpha1.NetworkConfig
+		networkConfigBirdExporter        *calicov1alpha1.NetworkConfig
+		networkConfigMultus              *calicov1alpha1.NetworkConfig
+		networkConfigVPATyphaDisabled    *calicov1alpha1.NetworkConfig
 
-		networkConfigNilFunc              = func() *calicov1alpha1.NetworkConfig { return networkConfigNil }
-		networkConfigNilValuesFunc        = func() *calicov1alpha1.NetworkConfig { return networkConfigNilValues }
-		networkConfigBackendNoneFunc      = func() *calicov1alpha1.NetworkConfig { return networkConfigBackendNone }
-		networkConfigAllFunc              = func() *calicov1alpha1.NetworkConfig { return networkConfigAll }
-		networkConfigAllMTUFunc           = func() *calicov1alpha1.NetworkConfig { return networkConfigAllMTU }
-		networkConfigAllFelixFunc         = func() *calicov1alpha1.NetworkConfig { return networkConfigAllFelix }
-		networkConfigAllEBPFDataplaneFunc = func() *calicov1alpha1.NetworkConfig { return networkConfigAllEBPFDataplane }
-		networkConfigDeprecatedFunc       = func() *calicov1alpha1.NetworkConfig { return networkConfigDeprecated }
-		networkConfigOverlayDisabledFunc  = func() *calicov1alpha1.NetworkConfig { return networkConfigOverlayDisabled }
-		networkConfigWireguardFunc        = func() *calicov1alpha1.NetworkConfig { return networkConfigWireguard }
-		networkConfigBirdExporterFunc     = func() *calicov1alpha1.NetworkConfig { return networkConfigBirdExporter }
-		networkConfigMultusFunc           = func() *calicov1alpha1.NetworkConfig { return networkConfigMultus }
-		networkConfigVPATyphaDisabledFunc = func() *calicov1alpha1.NetworkConfig { return networkConfigVPATyphaDisabled }
+		networkConfigNilFunc                 = func() *calicov1alpha1.NetworkConfig { return networkConfigNil }
+		networkConfigNilValuesFunc           = func() *calicov1alpha1.NetworkConfig { return networkConfigNilValues }
+		networkConfigBackendNoneFunc         = func() *calicov1alpha1.NetworkConfig { return networkConfigBackendNone }
+		networkConfigAllFunc                 = func() *calicov1alpha1.NetworkConfig { return networkConfigAll }
+		networkConfigAllMTUFunc              = func() *calicov1alpha1.NetworkConfig { return networkConfigAllMTU }
+		networkConfigAllFelixFunc            = func() *calicov1alpha1.NetworkConfig { return networkConfigAllFelix }
+		networkConfigAllEBPFDataplaneFunc    = func() *calicov1alpha1.NetworkConfig { return networkConfigAllEBPFDataplane }
+		networkConfigDeprecatedFunc          = func() *calicov1alpha1.NetworkConfig { return networkConfigDeprecated }
+		networkConfigOverlayDisabledFunc     = func() *calicov1alpha1.NetworkConfig { return networkConfigOverlayDisabled }
+		networkConfigOverlayDisabledBirdFunc = func() *calicov1alpha1.NetworkConfig { return networkConfigOverlayDisabledBird }
+		networkConfigWireguardFunc           = func() *calicov1alpha1.NetworkConfig { return networkConfigWireguard }
+		networkConfigBirdExporterFunc        = func() *calicov1alpha1.NetworkConfig { return networkConfigBirdExporter }
+		networkConfigMultusFunc              = func() *calicov1alpha1.NetworkConfig { return networkConfigMultus }
+		networkConfigVPATyphaDisabledFunc    = func() *calicov1alpha1.NetworkConfig { return networkConfigVPATyphaDisabled }
 
 		objectMeta = metav1.ObjectMeta{
 			Name:      "foo",
@@ -195,6 +197,16 @@ var _ = Describe("Chart package test", func() {
 				AutoDetectionMethod: &autodetectionMethod,
 			},
 			IPAutoDetectionMethod: &autodetectionMethod,
+		}
+		// overlay disabled with bird backend and no explicit IPv4 config — the real-world case
+		// where Felix must not create a tunl0 device
+		networkConfigOverlayDisabledBird = &calicov1alpha1.NetworkConfig{
+			Overlay: &calicov1alpha1.Overlay{Enabled: false},
+			Backend: &backendBird,
+			IPAM: &calicov1alpha1.IPAM{
+				CIDR: &podCIDR,
+				Type: "host-local",
+			},
 		}
 		networkConfigVPATyphaDisabled = &calicov1alpha1.NetworkConfig{
 			Backend: &backendBird,
@@ -391,6 +403,11 @@ var _ = Describe("Chart package test", func() {
 			networkConfigOverlayDisabledFunc, networkConfigOverlayDisabledFunc,
 			true, true, true, defaultMtu, false, false, pointer(corev1beta1.ProxyModeIPTables), string(poolIPIP), false, false, false,
 			func() string { return string(*networkConfigOverlayDisabled.IPv4.Mode) }, func() *string { return networkConfigOverlayDisabled.IPv4.AutoDetectionMethod },
+			func() *string { return nil }, map[string]string{"overlayEnabled": "false", "snatToUpstreamDNSEnabled": "true"}),
+		Entry("should disable felix ip in ip when overlay is disabled with bird backend and no explicit IPv4 config",
+			networkConfigOverlayDisabledBirdFunc, networkConfigOverlayDisabledBirdFunc,
+			true, true, true, defaultMtu, false, false, pointer(corev1beta1.ProxyModeIPTables), string(poolIPIP), false, false, false,
+			func() string { return string(never) }, func() *string { return nil },
 			func() *string { return nil }, map[string]string{"overlayEnabled": "false", "snatToUpstreamDNSEnabled": "true"}),
 		Entry("should respect deprecated fields in order to keep backwards compatibility",
 			networkConfigDeprecatedFunc, networkConfigDeprecatedFunc,

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -353,6 +353,13 @@ func mergeCalicoValuesWithConfig(c *calicoConfig, config *calicov1alpha1.Network
 		c.IPv4.Mode = calicov1alpha1.Never
 	}
 
+	// When overlay is explicitly disabled, IPIP serves no purpose. Disable it so Felix does
+	// not create a tunl0 device and does not subtract tunnel overhead from the MTU.
+	if config.Overlay != nil && !config.Overlay.Enabled {
+		c.Felix.IPInIP.Enabled = false
+		c.IPv4.Mode = calicov1alpha1.Never
+	}
+
 	if config.EbpfDataplane != nil && config.EbpfDataplane.Enabled {
 		c.Felix.BPF.Enabled = true
 		c.NonPrivileged = false


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind bug

**What this PR does / why we need it**:
When `spec.overlay.enabled: false` is set, the Calico IP-in-IP encapsulation serves no purpose — the cluster is intended to route pods directly. However, Felix was still creating a `tunl0` device and factoring tunnel overhead into MTU calculations, which wasted resources and could cause subtle networking issues.

This fix explicitly sets `Felix.IPInIP.Enabled = false` and `IPv4.Mode = Never` whenever overlay is disabled.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Disable Felix IP-in-IP when overlay is explicitly disabled to prevent unnecessary tunnel device creation and incorrect MTU overhead.
```
