### PR TITLE
fix(renovate): restrict quay.io/calico/node to v-prefixed tags

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -29,6 +29,12 @@
       "automerge": false
     },
     {
+      // quay.io/calico/node publishes tags both with and without the "v" prefix; restrict to v-prefixed ones.
+      "matchPackageNames": ["quay.io/calico/node"],
+      "matchDatasources": ["docker"],
+      "allowedVersions": "/^v/"
+    },
+    {
       // Group golang updates in one PR.
       "groupName": "golang",
       "matchDatasources": ["docker", "golang-version"],


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

`quay.io/calico/node` publishes image tags both with and without the "v"
prefix (e.g. both `3.31.7` and `v3.31.7`), causing Renovate to
consistently pick the non-prefixed tag. The other calico images are not
affected as they only publish v-prefixed tags.

This has been a recurring issue, previously fixed manually in ea048f31
(v3.30.7) and again in PR #902 (v3.31.7).

The fix adds an `allowedVersions: "/^v/"` package rule for
`quay.io/calico/node` so Renovate only considers v-prefixed tags when
looking up new versions.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
